### PR TITLE
Fix hiding display OSD when volume changed

### DIFF
--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -53,9 +53,7 @@ class Display {
       return
     }
 
-    for _ in 0..<20 {
-      _ = self.ddc?.write(command: .osd, value: UInt16(1), errorRecoveryWaitTime: 2000)
-    }
+    _ = self.ddc?.write(command: .osd, value: UInt16(1), errorRecoveryWaitTime: 2000)
   }
 
   func isMuted() -> Bool {

--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -48,12 +48,14 @@ class Display {
 
   // On some displays, the display's OSD overlaps the macOS OSD,
   // calling the OSD command with 1 seems to hide it.
-  func hideDisplayOsd() {
+  func hideDisplayOsd(repeatCommand: Bool = true) {
     guard self.hideOsd else {
       return
     }
 
-    _ = self.ddc?.write(command: .osd, value: UInt16(1), errorRecoveryWaitTime: 2000)
+    for _ in 0..<(repeatCommand ? 20 : 1) {
+      _ = self.ddc?.write(command: .osd, value: UInt16(1), errorRecoveryWaitTime: 2000)
+    }
   }
 
   func isMuted() -> Bool {

--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -48,13 +48,15 @@ class Display {
 
   // On some displays, the display's OSD overlaps the macOS OSD,
   // calling the OSD command with 1 seems to hide it.
-  func hideDisplayOsd(repeatCommand: Bool = true) {
+  func hideDisplayOsd() {
     guard self.hideOsd else {
       return
     }
 
-    for _ in 0..<(repeatCommand ? 20 : 1) {
-      _ = self.ddc?.write(command: .osd, value: UInt16(1), errorRecoveryWaitTime: 2000)
+    DispatchQueue.global(qos: .userInitiated).async {
+      for _ in 0..<20 {
+        _ = self.ddc?.write(command: .osd, value: UInt16(1), errorRecoveryWaitTime: 2000)
+      }
     }
   }
 

--- a/MonitorControl/UI/SliderHandler.swift
+++ b/MonitorControl/UI/SliderHandler.swift
@@ -42,7 +42,7 @@ class SliderHandler {
     self.display.saveValue(value, for: self.cmd)
 
     if self.cmd == .audioSpeakerVolume {
-      self.display.hideDisplayOsd()
+      self.display.hideDisplayOsd(repeatCommand: false)
     }
   }
 }

--- a/MonitorControl/UI/SliderHandler.swift
+++ b/MonitorControl/UI/SliderHandler.swift
@@ -40,5 +40,9 @@ class SliderHandler {
 
     _ = self.display.ddc?.write(command: self.cmd, value: UInt16(value))
     self.display.saveValue(value, for: self.cmd)
+
+    if self.cmd == .audioSpeakerVolume {
+      self.display.hideDisplayOsd()
+    }
   }
 }

--- a/MonitorControl/UI/SliderHandler.swift
+++ b/MonitorControl/UI/SliderHandler.swift
@@ -42,7 +42,7 @@ class SliderHandler {
     self.display.saveValue(value, for: self.cmd)
 
     if self.cmd == .audioSpeakerVolume {
-      self.display.hideDisplayOsd(repeatCommand: false)
+      self.display.hideDisplayOsd()
     }
   }
 }


### PR DESCRIPTION
This change also removes the 20x repeat of the hide OSD DDC command, per my comment in #136.