### PR TITLE
Fix flickering OSD and refactor logic for volume slider.

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "reitermarkus/DDC.swift" "41e7c49b0450033c5349ca1cf5234a26ebc011b8"
+github "reitermarkus/DDC.swift" "1763870c94c555ff93878caaec8235fd3a9a429d"
 github "rnine/AMCoreAudio" "3.3.1"
 github "shpakovski/MASPreferences" "1.3"
 github "the0neyouseek/MediaKeyTap" "3.1.0"

--- a/MonitorControl/Display.swift
+++ b/MonitorControl/Display.swift
@@ -77,11 +77,7 @@ class Display {
     let volumeDDCValue = UInt16(volumeOSDValue)
 
     DispatchQueue.global(qos: .userInitiated).async {
-      if self.ddc?.write(command: .audioSpeakerVolume, value: volumeDDCValue, errorRecoveryWaitTime: self.hideOsd ? 0 : nil) == true {
-        DispatchQueue.global(qos: .background).async {
-          self.saveValue(volumeOSDValue, for: .audioSpeakerVolume)
-        }
-      }
+      _ = self.ddc?.write(command: .audioSpeakerVolume, value: volumeDDCValue, errorRecoveryWaitTime: self.hideOsd ? 0 : nil)
 
       if self.supportsMuteCommand(), self.ddc?.write(command: .audioMuteScreenBlank, value: UInt16(muteValue), errorRecoveryWaitTime: self.hideOsd ? 0 : nil) == true {
         DispatchQueue.global(qos: .background).async {

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>716</string>
+	<string>724</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>574</string>
+	<string>716</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>716</string>
+	<string>724</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>574</string>
+	<string>716</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
This fixes the flickering/hiding of the display's OSD by readding `errorRecoveryWaitTime: self.hideOsd ? 0 : nil` which was removed.

Also, the volume slider now behaves the same way as the native macOS volume slider: It will only change the volume after a mouse-up event and it will also play the volume-changed sound.