### PR TITLE
If there isn't at least one enabled DDC external display, then don't tap any keys

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -31,7 +31,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     self.displayManager = DisplayManager()
     self.setupViewControllers()
     self.subscribeEventListeners()
-    self.startOrRestartMediaKeyTap()
     self.statusItem.image = NSImage(named: "status")
     self.statusItem.menu = self.statusMenu
     self.setDefaultPrefs()
@@ -111,6 +110,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.addDisplayToMenu(display: display, asSubMenu: ddcDisplays.count > 1)
       }
     }
+    self.startOrRestartMediaKeyTap()
   }
 
   private func addDisplayToMenu(display: ExternalDisplay, asSubMenu: Bool) {
@@ -273,7 +273,6 @@ extension AppDelegate: MediaKeyTapDelegate {
   @objc func handlePreferenceReset() {
     self.setDefaultPrefs()
     self.updateDisplays()
-    self.startOrRestartMediaKeyTap()
   }
 
   private func startOrRestartMediaKeyTap() {

--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -297,7 +297,7 @@ extension AppDelegate: MediaKeyTapDelegate {
     let ddcDisplays = DisplayManager.shared.getDdcCapableDisplays()
     var atLeastOne = false
     for display in ddcDisplays where display.isEnabled {
-      atLeastOne = true;
+      atLeastOne = true
       break
     }
 

--- a/MonitorControl/UI/Cells/ButtonCellView.swift
+++ b/MonitorControl/UI/Cells/ButtonCellView.swift
@@ -16,6 +16,7 @@ class ButtonCellView: NSTableCellView {
       #if DEBUG
         os_log("Toggle enabled display state: %{public}@", type: .info, isEnabled ? "on" : "off")
       #endif
+      NotificationCenter.default.post(name: Notification.Name(Utils.PrefKeys.listenFor.rawValue), object: nil)
     }
   }
 }


### PR DESCRIPTION
If there isn't at least one enabled DDC external display, then don't tap any keys. The use case for this is when a user wants to use MonitorControl for a monitor that resides in one location (e.g. their home), but does not want to use MonitorControl in another location (e.g. their workplace). But they also don't want to manually run or quit MonitorControl when they move locations.