### PR TITLE
Add a couple of basic entries back into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+### Carthage ###
 Carthage
 
-*.xcuserdatad
+### macOS ###
+.DS_Store
+
+### Xcode ###
+xcuserdata/
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings


### PR DESCRIPTION
During development, it's annoying to keep having to delete the `.DS_Store` files and the parts of the Xcode project file pertinent to personal workspace settings.