### PR TITLE
Show audio muted OSD image when audio volume value is 0

### DIFF
--- a/MonitorControl/Model/Display.swift
+++ b/MonitorControl/Model/Display.swift
@@ -64,25 +64,25 @@ class Display {
       osdImage = .brightness
     }
 
+    let filledChiclets: Int
+    let totalChiclets: Int
+
     if roundChiclet {
       let osdChiclet = OSDUtils.chiclet(fromValue: Float(value), maxValue: Float(maxValue))
-      let filledChiclets = round(osdChiclet)
-
-      manager.showImage(osdImage.rawValue,
-                        onDisplayID: self.identifier,
-                        priority: 0x1F4,
-                        msecUntilFade: 1000,
-                        filledChiclets: UInt32(filledChiclets),
-                        totalChiclets: UInt32(16),
-                        locked: false)
+      
+      filledChiclets = Int(round(osdChiclet))
+      totalChiclets = 16
     } else {
-      manager.showImage(osdImage.rawValue,
-                        onDisplayID: self.identifier,
-                        priority: 0x1F4,
-                        msecUntilFade: 1000,
-                        filledChiclets: UInt32(value),
-                        totalChiclets: UInt32(maxValue),
-                        locked: false)
+      filledChiclets = value
+      totalChiclets = maxValue
     }
+
+    manager.showImage(osdImage.rawValue,
+                      onDisplayID: self.identifier,
+                      priority: 0x1F4,
+                      msecUntilFade: 1000,
+                      filledChiclets: UInt32(filledChiclets),
+                      totalChiclets: UInt32(totalChiclets),
+                      locked: false)
   }
 }

--- a/MonitorControl/Model/Display.swift
+++ b/MonitorControl/Model/Display.swift
@@ -10,6 +10,12 @@ import DDC
 import Foundation
 import os.log
 
+private enum OSDImage: Int64 {
+  case brightness = 1
+  case audioSpeaker = 3
+  case audioSpeakerMuted = 4
+}
+
 class Display {
   internal let identifier: CGDirectDisplayID
   internal let name: String
@@ -48,23 +54,21 @@ class Display {
       return
     }
 
-    var osdImage: Int64!
+    var osdImage: OSDImage
     switch command {
-    case .brightness:
-      osdImage = 1 // Brightness Image
     case .audioSpeakerVolume:
-      osdImage = 3 // Speaker image
+      osdImage = value > 0 ? .audioSpeaker : .audioSpeakerMuted
     case .audioMuteScreenBlank:
-      osdImage = 4 // Mute image
+      osdImage = .audioSpeakerMuted
     default:
-      osdImage = 1
+      osdImage = .brightness
     }
 
     if roundChiclet {
       let osdChiclet = OSDUtils.chiclet(fromValue: Float(value), maxValue: Float(maxValue))
       let filledChiclets = round(osdChiclet)
 
-      manager.showImage(osdImage,
+      manager.showImage(osdImage.rawValue,
                         onDisplayID: self.identifier,
                         priority: 0x1F4,
                         msecUntilFade: 1000,
@@ -72,7 +76,7 @@ class Display {
                         totalChiclets: UInt32(16),
                         locked: false)
     } else {
-      manager.showImage(osdImage,
+      manager.showImage(osdImage.rawValue,
                         onDisplayID: self.identifier,
                         priority: 0x1F4,
                         msecUntilFade: 1000,


### PR DESCRIPTION
Currently, if you reduce the volume to zero, the OSD image is still the non-muted audio speaker, even though the volume is muted.

This change will set the OSD image to the muted audio speaker if the volume becomes zero.