### PR TITLE
Add an option to show color adjustment sliders

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -55,6 +55,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       prefs.set(true, forKey: Utils.PrefKeys.appAlreadyLaunched.rawValue)
 
       prefs.set(false, forKey: Utils.PrefKeys.showContrast.rawValue)
+      prefs.set(false, forKey: Utils.PrefKeys.showColorSliders.rawValue)
       prefs.set(false, forKey: Utils.PrefKeys.lowerContrast.rawValue)
     }
   }
@@ -114,6 +115,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let monitorSubMenu: NSMenu = asSubMenu ? NSMenu() : self.statusMenu
 
     self.statusMenu.insertItem(NSMenuItem.separator(), at: 0)
+    
+    if prefs.bool(forKey: Utils.PrefKeys.showColorSliders.rawValue) {
+      display.blueGainSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
+                                                         forDisplay: display,
+                                                         command: .videoGainBlue,
+                                                         title: NSLocalizedString("Blue Gain", comment: "Shown in menu"))
+      display.greenGainSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
+                                                         forDisplay: display,
+                                                         command: .videoGainGreen,
+                                                         title: NSLocalizedString("Green Gain", comment: "Shown in menu"))
+      display.redGainSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
+                                                         forDisplay: display,
+                                                         command: .videoGainRed,
+                                                         title: NSLocalizedString("Red Gain", comment: "Shown in menu"))
+    }
 
     let volumeSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
                                                       forDisplay: display,
@@ -170,6 +186,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // subscribe KeyTap event listener
     NotificationCenter.default.addObserver(self, selector: #selector(handleListenForChanged), name: .listenFor, object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handleShowContrastChanged), name: .showContrast, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(handleShowContrastChanged), name: .showColorSliders, object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handleFriendlyNameChanged), name: .friendlyName, object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handlePreferenceReset), name: .preferenceReset, object: nil)
 

--- a/MonitorControl/Extensions/NSNotification+Extension.swift
+++ b/MonitorControl/Extensions/NSNotification+Extension.swift
@@ -4,6 +4,7 @@ extension NSNotification.Name {
   static let accessibilityApi = NSNotification.Name(rawValue: "com.apple.accessibility.api")
   static let listenFor = NSNotification.Name(rawValue: Utils.PrefKeys.listenFor.rawValue)
   static let showContrast = NSNotification.Name(rawValue: Utils.PrefKeys.showContrast.rawValue)
+  static let showColorSliders = NSNotification.Name(rawValue: Utils.PrefKeys.showColorSliders.rawValue)
   static let friendlyName = NSNotification.Name(rawValue: Utils.PrefKeys.friendlyName.rawValue)
   static let preferenceReset = NSNotification.Name(rawValue: Utils.PrefKeys.preferenceReset.rawValue)
   static let displayListUpdate = NSNotification.Name(rawValue: Utils.PrefKeys.displayListUpdate.rawValue)

--- a/MonitorControl/Model/ExternalDisplay.swift
+++ b/MonitorControl/Model/ExternalDisplay.swift
@@ -7,6 +7,9 @@ class ExternalDisplay: Display {
   var brightnessSliderHandler: SliderHandler?
   var volumeSliderHandler: SliderHandler?
   var contrastSliderHandler: SliderHandler?
+  var redGainSliderHandler: SliderHandler?
+  var greenGainSliderHandler: SliderHandler?
+  var blueGainSliderHandler: SliderHandler?
   var ddc: DDC?
 
   private let prefs = UserDefaults.standard

--- a/MonitorControl/Support/Utils.swift
+++ b/MonitorControl/Support/Utils.swift
@@ -149,6 +149,9 @@ class Utils: NSObject {
 
     /// Show contrast sliders
     case showContrast
+    
+    /// Show color adjustment sliders
+    case showColorSliders
 
     /// Lower contrast after brightness
     case lowerContrast

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -445,28 +445,38 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button verticalHuggingPriority="750" id="hWd-f4-Tcg" userLabel="Show color adjustment sliders">
+                                <rect key="frame" x="236" y="52" width="201" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                <buttonCell key="cell" type="check" title="Show color adustment sliders" bezelStyle="regularSquare" imagePosition="left" inset="2" id="MxJ-Xq-RmA">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showColorSlidersClicked:" target="BGD-tY-Myx" id="2B8-uM-nBm"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="i5K-Cd-wxm" secondAttribute="trailing" constant="20" id="7p3-HQ-gLl"/>
-                            <constraint firstItem="xGa-qG-9ut" firstAttribute="top" secondItem="9Gu-aU-Td2" secondAttribute="bottom" constant="20" id="DOL-i0-bCI"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9Gu-aU-Td2" secondAttribute="trailing" constant="20" id="Gft-KX-rdy"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xGa-qG-9ut" secondAttribute="trailing" constant="20" id="HDL-zX-2dq"/>
                             <constraint firstItem="9Gu-aU-Td2" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="MwQ-M8-u18"/>
-                            <constraint firstItem="xGa-qG-9ut" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="NgS-ga-iNo"/>
-                            <constraint firstItem="i5K-Cd-wxm" firstAttribute="top" secondItem="xGa-qG-9ut" secondAttribute="bottom" constant="20" id="R2I-Ko-ZJ9"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="siR-fL-v2a" secondAttribute="trailing" constant="20" id="Srs-vY-IQB"/>
+                            <constraint firstItem="xGa-qG-9ut" firstAttribute="leading" secondItem="9Gu-aU-Td2" secondAttribute="leading" id="YJ4-Zc-7mX"/>
                             <constraint firstItem="9Gu-aU-Td2" firstAttribute="top" secondItem="tMg-qE-zTW" secondAttribute="bottom" constant="20" id="caN-Et-n47"/>
                             <constraint firstItem="siR-fL-v2a" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="eXs-op-WJj"/>
                             <constraint firstItem="siR-fL-v2a" firstAttribute="top" secondItem="COE-Oc-gZs" secondAttribute="top" constant="20" id="iTz-r7-NFb"/>
                             <constraint firstItem="i5K-Cd-wxm" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="jWI-DQ-WdT"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tMg-qE-zTW" secondAttribute="trailing" constant="20" id="jzw-7W-4cW"/>
                             <constraint firstItem="tMg-qE-zTW" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="qhb-hw-Gwg"/>
+                            <constraint firstItem="xGa-qG-9ut" firstAttribute="baseline" secondItem="hWd-f4-Tcg" secondAttribute="baseline" id="u4X-pL-f6p"/>
                             <constraint firstAttribute="bottom" secondItem="i5K-Cd-wxm" secondAttribute="bottom" constant="20" id="xxz-YT-Uma"/>
                             <constraint firstItem="tMg-qE-zTW" firstAttribute="top" secondItem="siR-fL-v2a" secondAttribute="bottom" constant="20" id="zis-v1-6aZ"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="lowerContrast" destination="i5K-Cd-wxm" id="sE8-Ra-JSn"/>
+                        <outlet property="showColorSliders" destination="hWd-f4-Tcg" id="GrH-u9-MPI"/>
                         <outlet property="showContrastSlider" destination="xGa-qG-9ut" id="AzL-sx-Z8Q"/>
                         <outlet property="startAtLogin" destination="9Gu-aU-Td2" id="Tyx-Ub-Cyf"/>
                         <outlet property="versionLabel" destination="tMg-qE-zTW" id="31N-s8-URL"/>

--- a/MonitorControl/View Controllers/MainPrefsViewController.swift
+++ b/MonitorControl/View Controllers/MainPrefsViewController.swift
@@ -12,6 +12,7 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
   @IBOutlet var versionLabel: NSTextField!
   @IBOutlet var startAtLogin: NSButton!
   @IBOutlet var showContrastSlider: NSButton!
+  @IBOutlet var showColorSliders: NSButton!
   @IBOutlet var lowerContrast: NSButton!
 
   override func viewDidLoad() {
@@ -25,6 +26,7 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
     let startAtLogin = (SMCopyAllJobDictionaries(kSMDomainUserLaunchd).takeRetainedValue() as? [[String: AnyObject]])?.first { $0["Label"] as? String == "\(Bundle.main.bundleIdentifier!)Helper" }?["OnDemand"] as? Bool ?? false
     self.startAtLogin.state = startAtLogin ? .on : .off
     self.showContrastSlider.state = self.prefs.bool(forKey: Utils.PrefKeys.showContrast.rawValue) ? .on : .off
+    self.showColorSliders.state = self.prefs.bool(forKey: Utils.PrefKeys.showColorSliders.rawValue) ? .on : .off
     self.lowerContrast.state = self.prefs.bool(forKey: Utils.PrefKeys.lowerContrast.rawValue) ? .on : .off
   }
 
@@ -53,7 +55,26 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
 
     NotificationCenter.default.post(name: Notification.Name(Utils.PrefKeys.showContrast.rawValue), object: nil)
   }
-
+  
+  @IBAction func showColorSlidersClicked(_ sender: NSButton) {
+    switch sender.state {
+    case .on:
+      self.prefs.set(true, forKey:
+          Utils.PrefKeys.showColorSliders.rawValue)
+    case .off:
+      self.prefs.set(false, forKey:
+          Utils.PrefKeys.showColorSliders.rawValue)
+    default: break
+    }
+    
+    #if DEBUG
+    os_log("Toggle show color sliders state: %{public}@", type: .info, sender.state == .on ? "on" : "off")
+    #endif
+    
+    NotificationCenter.default.post(name: Notification.Name(Utils.PrefKeys.showColorSliders.rawValue),
+        object:nil)
+  }
+  
   @IBAction func lowerContrastClicked(_ sender: NSButton) {
     switch sender.state {
     case .on:


### PR DESCRIPTION
This pull request adds an option to show red/green/blue gain adjustment sliders. It can be enabled from the preferences screen.

If the external monitor supports these commands, these sliders can be used to make quick adjustments to the white balance with changing ambient light conditions throughout the day. It's useful for people whose work desk is next to a window.