### PR TITLE
Add show volume slider option

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -54,6 +54,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if !prefs.bool(forKey: Utils.PrefKeys.appAlreadyLaunched.rawValue) {
       prefs.set(true, forKey: Utils.PrefKeys.appAlreadyLaunched.rawValue)
 
+      prefs.set(true, forKey: Utils.PrefKeys.showVolume.rawValue)
       prefs.set(false, forKey: Utils.PrefKeys.showContrast.rawValue)
       prefs.set(false, forKey: Utils.PrefKeys.lowerContrast.rawValue)
     }
@@ -115,10 +116,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     self.statusMenu.insertItem(NSMenuItem.separator(), at: 0)
 
-    let volumeSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
-                                                      forDisplay: display,
-                                                      command: .audioSpeakerVolume,
-                                                      title: NSLocalizedString("Volume", comment: "Shown in menu"))
+    if prefs.bool(forKey: Utils.PrefKeys.showVolume.rawValue) {
+      let volumeSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
+                                                        forDisplay: display,
+                                                        command: .audioSpeakerVolume,
+                                                        title: NSLocalizedString("Volume", comment: "Shown in menu"))
+      display.volumeSliderHandler = volumeSliderHandler
+    }
     let brightnessSliderHandler = Utils.addSliderMenuItem(toMenu: monitorSubMenu,
                                                           forDisplay: display,
                                                           command: .brightness,
@@ -131,7 +135,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       display.contrastSliderHandler = contrastSliderHandler
     }
 
-    display.volumeSliderHandler = volumeSliderHandler
     display.brightnessSliderHandler = brightnessSliderHandler
 
     let monitorMenuItem = NSMenuItem()
@@ -169,6 +172,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   private func subscribeEventListeners() {
     // subscribe KeyTap event listener
     NotificationCenter.default.addObserver(self, selector: #selector(handleListenForChanged), name: .listenFor, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(handleShowVolumeChanged), name: .showVolume, object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handleShowContrastChanged), name: .showContrast, object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handleFriendlyNameChanged), name: .friendlyName, object: nil)
     NotificationCenter.default.addObserver(self, selector: #selector(handlePreferenceReset), name: .preferenceReset, object: nil)
@@ -291,6 +295,10 @@ extension AppDelegate: MediaKeyTapDelegate {
   @objc func handleListenForChanged() {
     self.checkPermissions()
     self.updateMediaKeyTap()
+  }
+
+  @objc func handleShowVolumeChanged() {
+    self.updateDisplays()
   }
 
   @objc func handleShowContrastChanged() {

--- a/MonitorControl/Extensions/NSNotification+Extension.swift
+++ b/MonitorControl/Extensions/NSNotification+Extension.swift
@@ -3,6 +3,7 @@ import Cocoa
 extension NSNotification.Name {
   static let accessibilityApi = NSNotification.Name(rawValue: "com.apple.accessibility.api")
   static let listenFor = NSNotification.Name(rawValue: Utils.PrefKeys.listenFor.rawValue)
+  static let showVolume = NSNotification.Name(rawValue: Utils.PrefKeys.showVolume.rawValue)
   static let showContrast = NSNotification.Name(rawValue: Utils.PrefKeys.showContrast.rawValue)
   static let friendlyName = NSNotification.Name(rawValue: Utils.PrefKeys.friendlyName.rawValue)
   static let preferenceReset = NSNotification.Name(rawValue: Utils.PrefKeys.preferenceReset.rawValue)

--- a/MonitorControl/Support/Utils.swift
+++ b/MonitorControl/Support/Utils.swift
@@ -147,6 +147,9 @@ class Utils: NSObject {
     /// Keys listened for (Brightness/Volume)
     case listenFor
 
+    /// Show volume sliders
+    case showVolume
+
     /// Show contrast sliders
     case showContrast
 

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -417,6 +417,16 @@
                                     <action selector="startAtLoginClicked:" target="BGD-tY-Myx" id="QvH-5O-Lck"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fey-NE-wyx">
+                                <rect key="frame" x="18" y="86" width="171" height="18"/>
+                                <buttonCell key="cell" type="check" title="Show a slider for volume" bezelStyle="regularSquare" imagePosition="left" inset="2" id="lGa-Bb-oVu">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showVolumeSliderClicked:" target="BGD-tY-Myx" id="jpx-09-3tn"/>
+                                </connections>
+                            </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xGa-qG-9ut">
                                 <rect key="frame" x="18" y="55" width="181" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show a slider for contrast" bezelStyle="regularSquare" imagePosition="left" inset="2" id="xSI-8W-Xd0">
@@ -448,14 +458,17 @@
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="i5K-Cd-wxm" secondAttribute="trailing" constant="20" id="7p3-HQ-gLl"/>
-                            <constraint firstItem="xGa-qG-9ut" firstAttribute="top" secondItem="9Gu-aU-Td2" secondAttribute="bottom" constant="20" id="DOL-i0-bCI"/>
+                            <constraint firstItem="xGa-qG-9ut" firstAttribute="top" secondItem="Fey-NE-wyx" secondAttribute="bottom" constant="20" id="DOL-i0-bCI"/>
+                            <constraint firstItem="Fey-NE-wyx" firstAttribute="top" secondItem="9Gu-aU-Td2" secondAttribute="bottom" constant="20" id="DZ0-lX-muY"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9Gu-aU-Td2" secondAttribute="trailing" constant="20" id="Gft-KX-rdy"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xGa-qG-9ut" secondAttribute="trailing" constant="20" id="HDL-zX-2dq"/>
                             <constraint firstItem="9Gu-aU-Td2" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="MwQ-M8-u18"/>
                             <constraint firstItem="xGa-qG-9ut" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="NgS-ga-iNo"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Fey-NE-wyx" secondAttribute="trailing" constant="20" id="Pxf-gn-wul"/>
                             <constraint firstItem="i5K-Cd-wxm" firstAttribute="top" secondItem="xGa-qG-9ut" secondAttribute="bottom" constant="20" id="R2I-Ko-ZJ9"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="siR-fL-v2a" secondAttribute="trailing" constant="20" id="Srs-vY-IQB"/>
                             <constraint firstItem="9Gu-aU-Td2" firstAttribute="top" secondItem="tMg-qE-zTW" secondAttribute="bottom" constant="20" id="caN-Et-n47"/>
+                            <constraint firstItem="Fey-NE-wyx" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="eU9-NM-CyY"/>
                             <constraint firstItem="siR-fL-v2a" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="eXs-op-WJj"/>
                             <constraint firstItem="siR-fL-v2a" firstAttribute="top" secondItem="COE-Oc-gZs" secondAttribute="top" constant="20" id="iTz-r7-NFb"/>
                             <constraint firstItem="i5K-Cd-wxm" firstAttribute="leading" secondItem="COE-Oc-gZs" secondAttribute="leading" constant="20" id="jWI-DQ-WdT"/>
@@ -468,6 +481,7 @@
                     <connections>
                         <outlet property="lowerContrast" destination="i5K-Cd-wxm" id="sE8-Ra-JSn"/>
                         <outlet property="showContrastSlider" destination="xGa-qG-9ut" id="AzL-sx-Z8Q"/>
+                        <outlet property="showVolumeSlider" destination="Fey-NE-wyx" id="ClC-m3-iEy"/>
                         <outlet property="startAtLogin" destination="9Gu-aU-Td2" id="Tyx-Ub-Cyf"/>
                         <outlet property="versionLabel" destination="tMg-qE-zTW" id="31N-s8-URL"/>
                     </connections>

--- a/MonitorControl/UI/de.lproj/Main.strings
+++ b/MonitorControl/UI/de.lproj/Main.strings
@@ -103,6 +103,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "DDC"; ObjectID = "xFw-if-3FU"; */
 "xFw-if-3FU.headerCell.title" = "DDC";
 
+/* Class = "NSButtonCell"; title = "Show a slider for volume"; ObjectID = "lGa-Bb-oVu"; */
+"lGa-Bb-oVu.title" = "Slider für Lautstärke anzeigen";
+
 /* Class = "NSButtonCell"; title = "Show a slider for contrast"; ObjectID = "xSI-8W-Xd0"; */
 "xSI-8W-Xd0.title" = "Slider für Kontrast anzeigen";
 

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -103,6 +103,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "DDC"; ObjectID = "xFw-if-3FU"; */
 "xFw-if-3FU.headerCell.title" = "DDC";
 
+/* Class = "NSButtonCell"; title = "Show a slider for volume"; ObjectID = "lGa-Bb-oVu"; */
+"lGa-Bb-oVu.title" = "Show a slider for volume";
+
 /* Class = "NSButtonCell"; title = "Show a slider for contrast"; ObjectID = "xSI-8W-Xd0"; */
 "xSI-8W-Xd0.title" = "Show a slider for contrast";
 

--- a/MonitorControl/UI/fr.lproj/Main.strings
+++ b/MonitorControl/UI/fr.lproj/Main.strings
@@ -103,6 +103,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "DDC"; ObjectID = "xFw-if-3FU"; */
 "xFw-if-3FU.headerCell.title" = "DDC";
 
+/* Class = "NSButtonCell"; title = "Show a slider for volume"; ObjectID = "lGa-Bb-oVu"; */
+"lGa-Bb-oVu.title" = "Afficher un slide pour le volume";
+
 /* Class = "NSButtonCell"; title = "Show a slider for contrast"; ObjectID = "xSI-8W-Xd0"; */
 "xSI-8W-Xd0.title" = "Afficher un slide pour le contraste";
 

--- a/MonitorControl/UI/ja.lproj/Main.strings
+++ b/MonitorControl/UI/ja.lproj/Main.strings
@@ -121,6 +121,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "DDC"; ObjectID = "xFw-if-3FU"; */
 "xFw-if-3FU.headerCell.title" = "DDC";
 
+/* Class = "NSButtonCell"; title = "Show a slider for volume"; ObjectID = "lGa-Bb-oVu"; */
+"lGa-Bb-oVu.title" = "音量変更用のスライダーをメニューに表示する";
+
 /* Class = "NSButtonCell"; title = "Show a slider for contrast"; ObjectID = "xSI-8W-Xd0"; */
 "xSI-8W-Xd0.title" = "コントラスト変更用のスライダーをメニューに表示する";
 

--- a/MonitorControl/UI/zh-Hans.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/Main.strings
@@ -103,6 +103,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "DDC"; ObjectID = "xFw-if-3FU"; */
 "xFw-if-3FU.headerCell.title" = "DDC";
 
+/* Class = "NSButtonCell"; title = "Show a slider for volume"; ObjectID = "lGa-Bb-oVu"; */
+"lGa-Bb-oVu.title" = "显示音量滑动条";
+
 /* Class = "NSButtonCell"; title = "Show a slider for contrast"; ObjectID = "xSI-8W-Xd0"; */
 "xSI-8W-Xd0.title" = "显示对比度滑动条";
 

--- a/MonitorControl/View Controllers/MainPrefsViewController.swift
+++ b/MonitorControl/View Controllers/MainPrefsViewController.swift
@@ -11,6 +11,7 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
 
   @IBOutlet var versionLabel: NSTextField!
   @IBOutlet var startAtLogin: NSButton!
+  @IBOutlet var showVolumeSlider: NSButton!
   @IBOutlet var showContrastSlider: NSButton!
   @IBOutlet var lowerContrast: NSButton!
 
@@ -24,6 +25,7 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
     super.viewWillAppear()
     let startAtLogin = (SMCopyAllJobDictionaries(kSMDomainUserLaunchd).takeRetainedValue() as? [[String: AnyObject]])?.first { $0["Label"] as? String == "\(Bundle.main.bundleIdentifier!)Helper" }?["OnDemand"] as? Bool ?? false
     self.startAtLogin.state = startAtLogin ? .on : .off
+    self.showVolumeSlider.state = self.prefs.bool(forKey: Utils.PrefKeys.showVolume.rawValue) ? .on : .off
     self.showContrastSlider.state = self.prefs.bool(forKey: Utils.PrefKeys.showContrast.rawValue) ? .on : .off
     self.lowerContrast.state = self.prefs.bool(forKey: Utils.PrefKeys.lowerContrast.rawValue) ? .on : .off
   }
@@ -36,6 +38,22 @@ class MainPrefsViewController: NSViewController, MASPreferencesViewController {
       Utils.setStartAtLogin(enabled: false)
     default: break
     }
+  }
+
+  @IBAction func showVolumeSliderClicked(_ sender: NSButton) {
+    switch sender.state {
+    case .on:
+      self.prefs.set(true, forKey: Utils.PrefKeys.showVolume.rawValue)
+    case .off:
+      self.prefs.set(false, forKey: Utils.PrefKeys.showVolume.rawValue)
+    default: break
+    }
+
+    #if DEBUG
+      os_log("Toggle show volume slider state: %{public}@", type: .info, sender.state == .on ? "on" : "off")
+    #endif
+
+    NotificationCenter.default.post(name: Notification.Name(Utils.PrefKeys.showVolume.rawValue), object: nil)
   }
 
   @IBAction func showContrastSliderClicked(_ sender: NSButton) {


### PR DESCRIPTION
> Unfortunately most displays don't have an audio mixer for adjusting volume.
> An option for hiding volume slider would be preferred.

**Note**

- Storyboard updated under VIM, might need to re-save in Xcode.
- Translations for the following strings not implemented for Ukrainian, Russian, Italian, Polish. (Sorry I don't speak those languages)

```
/* Class = "NSButtonCell"; title = "Show a slider for volume"; ObjectID = "lGa-Bb-oVu"; */
"lGa-Bb-oVu.title" = "Show a slider for volume";
```