### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Go to [Release](https://github.com/the0neyouseek/MonitorControl/releases/latest)
 You can also install MonitorControl with [Homebrew Cask](https://github.com/Homebrew/homebrew-cask).
 
 ```bash
-$ brew cask install monitorcontrol
+$ brew install --cask monitorcontrol
 ```
 
 ## How to help


### PR DESCRIPTION
Installing casks using the command `brew cask install` has been deprecated since Homebrew 2.6.0 [0], hence the command suggested in the README for installing the application no longer works.

This PR simply corrects it to work on recent versions of cask, using the `brew cask --install` form.

[0] https://brew.sh/2020/12/01/homebrew-2.6.0/