### PR TITLE
Made enabling mute/unmute an advanced preference (#170)

### DIFF
--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		6CBFE27C23DB27A200D1BC41 /* InternalDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBFE27B23DB27A200D1BC41 /* InternalDisplay.swift */; };
 		6CCB278622D5315200619B05 /* HideOsdCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCB278522D5315200619B05 /* HideOsdCellView.swift */; };
 		6CD444C322D4FBB8005BFD3D /* LongerDelayCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD444C222D4FBB8005BFD3D /* LongerDelayCellView.swift */; };
+		70D5BAB0258E9D8A00355938 /* EnableMuteCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D5BAAF258E9D8A00355938 /* EnableMuteCellView.swift */; };
 		F01B0699228221B7008E64DB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F01B0680228221B6008E64DB /* Localizable.strings */; };
 		F01B069A228221B7008E64DB /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01B0683228221B6008E64DB /* Utils.swift */; };
 		F01B069E228221B7008E64DB /* ButtonCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01B068E228221B6008E64DB /* ButtonCellView.swift */; };
@@ -138,6 +139,7 @@
 		6CBFE27B23DB27A200D1BC41 /* InternalDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalDisplay.swift; sourceTree = "<group>"; };
 		6CCB278522D5315200619B05 /* HideOsdCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideOsdCellView.swift; sourceTree = "<group>"; };
 		6CD444C222D4FBB8005BFD3D /* LongerDelayCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongerDelayCellView.swift; sourceTree = "<group>"; };
+		70D5BAAF258E9D8A00355938 /* EnableMuteCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableMuteCellView.swift; sourceTree = "<group>"; };
 		B0C4810623357CE500053F91 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B0C4810723357CE500053F91 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Main.strings; sourceTree = "<group>"; };
 		B0C4810823357CE500053F91 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/MainMenu.strings; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				6C85EFDE22CBB54100227EA1 /* PollingCountCellView.swift */,
 				6CD444C222D4FBB8005BFD3D /* LongerDelayCellView.swift */,
 				6CCB278522D5315200619B05 /* HideOsdCellView.swift */,
+				70D5BAAF258E9D8A00355938 /* EnableMuteCellView.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -559,6 +562,7 @@
 				6CBFE27C23DB27A200D1BC41 /* InternalDisplay.swift in Sources */,
 				FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */,
 				6CBFE27A23DB266000D1BC41 /* Display.swift in Sources */,
+				70D5BAB0258E9D8A00355938 /* EnableMuteCellView.swift in Sources */,
 				F03A8DF21FFBAA6F0034DC27 /* ExternalDisplay.swift in Sources */,
 				F0445D40200259C10025AE82 /* DisplayPrefsViewController.swift in Sources */,
 				28D1DDF0227FBD99004CB494 /* EDID+Extension.swift in Sources */,

--- a/MonitorControl/Model/ExternalDisplay.swift
+++ b/MonitorControl/Model/ExternalDisplay.swift
@@ -11,6 +11,16 @@ class ExternalDisplay: Display {
 
   private let prefs = UserDefaults.standard
 
+  var enableMuteUnmute: Bool {
+    get {
+      return self.prefs.bool(forKey: "enableMuteUnmute-\(self.identifier)")
+    }
+    set {
+      self.prefs.set(newValue, forKey: "enableMuteUnmute-\(self.identifier)")
+      os_log("Set `enableMuteUnmute` for %{private}@ to: %{public}@", type: .info, String(self.identifier), String(newValue))
+    }
+  }
+
   var hideOsd: Bool {
     get {
       return self.prefs.bool(forKey: "hideOsd-\(self.identifier)")
@@ -79,7 +89,7 @@ class ExternalDisplay: Display {
       return
     }
 
-    if self.supportsMuteCommand() {
+    if self.enableMuteUnmute {
       guard self.ddc?.write(command: .audioMuteScreenBlank, value: UInt16(muteValue)) == true else {
         return
       }
@@ -120,8 +130,7 @@ class ExternalDisplay: Display {
     }
 
     if let muteValue = muteValue {
-      // If the mute command is supported, set its value accordingly
-      if self.supportsMuteCommand() {
+      if self.enableMuteUnmute {
         guard self.ddc?.write(command: .audioMuteScreenBlank, value: UInt16(muteValue)) == true else {
           return
         }
@@ -318,11 +327,6 @@ class ExternalDisplay: Display {
 
   override func showOsd(command: DDC.Command, value: Int, maxValue _: Int = 100, roundChiclet: Bool = false) {
     super.showOsd(command: command, value: value, maxValue: self.getMaxValue(for: command), roundChiclet: roundChiclet)
-  }
-
-  private func supportsMuteCommand() -> Bool {
-    // Monitors which don't support the mute command - e.g. Dell U3419W - will have a maximum value of 100 for the DDC mute command
-    return self.getMaxValue(for: .audioMuteScreenBlank) == 2
   }
 
   private func playVolumeChangedSound() {

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.3"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,7 +18,7 @@
                                 <rect key="frame" x="85" y="17" width="197" height="25"/>
                                 <popUpButtonCell key="cell" type="push" title="Both Brightness &amp; Volume" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Vr4-xb-B4o" id="DkZ-as-YDS">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="menu"/>
+                                    <font key="font" metaFont="system"/>
                                     <menu key="menu" id="Hqj-cU-ZyP">
                                         <items>
                                             <menuItem title="Both Brightness &amp; Volume" state="on" id="Vr4-xb-B4o">
@@ -86,7 +86,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uXD-ZY-N3H">
-                                <rect key="frame" x="18" y="175" width="87" height="28"/>
+                                <rect key="frame" x="18" y="175" width="88" height="28"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display" id="ExD-7P-6XI">
                                     <font key="font" metaFont="systemBold" size="24"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -94,13 +94,13 @@
                                 </textFieldCell>
                             </textField>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B5k-we-kuP">
-                                <rect key="frame" x="20" y="20" width="637" height="99"/>
+                                <rect key="frame" x="20" y="20" width="637" height="101"/>
                                 <clipView key="contentView" drawsBackground="NO" id="4ot-Jo-X5O">
-                                    <rect key="frame" x="1" y="1" width="635" height="97"/>
+                                    <rect key="frame" x="1" y="0.0" width="635" height="100"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" headerView="ckY-Px-mJn" viewBased="YES" id="dyo-uY-pMe">
-                                            <rect key="frame" x="0.0" y="0.0" width="687" height="74"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="687" height="77"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -108,7 +108,6 @@
                                             <tableColumns>
                                                 <tableColumn width="49" minWidth="40" maxWidth="1000" id="8U8-ec-Zbv">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Enabled">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -139,7 +138,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="49" minWidth="40" maxWidth="1000" id="xFw-if-3FU">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="DDC">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -170,7 +168,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="140" minWidth="40" maxWidth="1000" id="CHc-s5-4MN">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Name">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -203,7 +200,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="140" minWidth="40" maxWidth="1000" id="uoI-1J-RdD">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Friendly Name">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -239,7 +235,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="80" minWidth="10" maxWidth="3.4028234663852886e+38" id="dgp-q7-cBK">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="ID">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -272,7 +267,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="80" minWidth="10" maxWidth="3.4028234663852886e+38" id="LRJ-fb-Z9E">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Vendor">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -305,7 +299,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="128" minWidth="10" maxWidth="3.4028234663852886e+38" id="Nvp-hI-w4x">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Model">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -359,7 +352,7 @@
                                 </tableHeaderView>
                             </scrollView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y48-gQ-uJi">
-                                <rect key="frame" x="18" y="138" width="279" height="18"/>
+                                <rect key="frame" x="18" y="139" width="275" height="18"/>
                                 <buttonCell key="cell" type="check" title="Change Brightness/Volume for all screens" bezelStyle="regularSquare" imagePosition="left" inset="2" id="0Z7-PQ-Bl8">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -396,11 +389,11 @@
             <objects>
                 <viewController storyboardIdentifier="MainPrefsVC" id="BGD-tY-Myx" customClass="MainPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="COE-Oc-gZs">
-                        <rect key="frame" x="0.0" y="0.0" width="486" height="212"/>
+                        <rect key="frame" x="0.0" y="0.0" width="486" height="206"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="siR-fL-v2a">
-                                <rect key="frame" x="18" y="164" width="92" height="28"/>
+                                <rect key="frame" x="18" y="158" width="92" height="28"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="General" id="ENU-js-huy">
                                     <font key="font" metaFont="systemBold" size="24"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -408,7 +401,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Gu-aU-Td2">
-                                <rect key="frame" x="18" y="91" width="203" height="18"/>
+                                <rect key="frame" x="18" y="86" width="199" height="18"/>
                                 <buttonCell key="cell" type="check" title="Start MonitorControl at Login" bezelStyle="regularSquare" imagePosition="left" inset="2" id="j72-NF-zsW">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -418,7 +411,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xGa-qG-9ut">
-                                <rect key="frame" x="18" y="55" width="181" height="18"/>
+                                <rect key="frame" x="18" y="52" width="177" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show a slider for contrast" bezelStyle="regularSquare" imagePosition="left" inset="2" id="xSI-8W-Xd0">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -428,7 +421,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="i5K-Cd-wxm">
-                                <rect key="frame" x="18" y="19" width="219" height="18"/>
+                                <rect key="frame" x="18" y="18" width="215" height="18"/>
                                 <buttonCell key="cell" type="check" title="Lower Contrast after Brightness" bezelStyle="regularSquare" imagePosition="left" inset="2" id="fhy-Er-0aI">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -438,7 +431,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tMg-qE-zTW">
-                                <rect key="frame" x="18" y="128" width="138" height="16"/>
+                                <rect key="frame" x="18" y="122" width="138" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Version 0.0.0 (Build 0)" id="mBs-6m-13Q">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -481,11 +474,11 @@
             <objects>
                 <viewController storyboardIdentifier="AdvancedPrefsVC" id="xjG-x0-7HO" customClass="AdvancedPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" misplaced="YES" id="MqL-7s-HoR">
-                        <rect key="frame" x="0.0" y="0.0" width="629" height="286"/>
+                        <rect key="frame" x="0.0" y="0.0" width="708" height="286"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="moz-ZW-I46">
-                                <rect key="frame" x="18" y="238" width="117" height="28"/>
+                                <rect key="frame" x="18" y="238" width="118" height="28"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Advanced" id="5wk-Dy-0fG">
                                     <font key="font" metaFont="systemBold" size="24"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -493,13 +486,13 @@
                                 </textFieldCell>
                             </textField>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VCP-xz-0jI">
-                                <rect key="frame" x="20" y="62" width="591" height="104"/>
+                                <rect key="frame" x="20" y="61" width="681" height="80"/>
                                 <clipView key="contentView" drawsBackground="NO" id="EAu-T4-lFV">
-                                    <rect key="frame" x="1" y="1" width="589" height="102"/>
+                                    <rect key="frame" x="1" y="0.0" width="679" height="79"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="20" rowSizeStyle="automatic" headerView="qVc-cy-LaW" viewBased="YES" id="t7B-Q7-Ssj">
-                                            <rect key="frame" x="0.0" y="0.0" width="589" height="77"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="679" height="54"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -507,7 +500,6 @@
                                             <tableColumns>
                                                 <tableColumn width="122" minWidth="40" maxWidth="1000" id="dNl-I0-hcg">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Display Name">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -540,7 +532,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="108" minWidth="10" maxWidth="3.4028234663852886e+38" id="JKW-oY-bSb">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="ID">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -573,13 +564,12 @@
                                                 </tableColumn>
                                                 <tableColumn width="95" minWidth="10" maxWidth="3.4028234663852886e+38" id="gxn-NH-Qhb">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Polling Mode">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
                                                     <popUpButtonCell key="dataCell" type="bevel" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="bezel" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="1vY-Fh-0Cn">
                                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="menu"/>
+                                                        <font key="font" metaFont="system"/>
                                                         <menu key="menu" id="fyQ-11-vzK"/>
                                                     </popUpButtonCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
@@ -589,13 +579,13 @@
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7FH-uw-jcn">
-                                                                    <rect key="frame" x="5" y="-3" width="86" height="23"/>
+                                                                    <rect key="frame" x="6" y="-3" width="85" height="24"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="20" id="2Bp-6e-RcJ"/>
                                                                     </constraints>
                                                                     <popUpButtonCell key="cell" type="push" title="Normal" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="2" imageScaling="proportionallyDown" inset="2" selectedItem="Riq-uM-bTs" id="M5p-a2-UEs">
                                                                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="menu"/>
+                                                                        <font key="font" metaFont="system"/>
                                                                         <menu key="menu" id="Nil-kM-Hvj">
                                                                             <items>
                                                                                 <menuItem title="None" id="FoA-yh-Yx3"/>
@@ -623,7 +613,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="99" minWidth="10" maxWidth="3.4028234663852886e+38" id="ytT-up-Dhs">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Polling Count">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </tableHeaderCell>
@@ -660,7 +649,6 @@
                                                 </tableColumn>
                                                 <tableColumn width="79" minWidth="40" maxWidth="1000" id="grO-Kr-l4d">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Longer Delay">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -689,9 +677,8 @@
                                                         </tableCellView>
                                                     </prototypeCellViews>
                                                 </tableColumn>
-                                                <tableColumn width="68" minWidth="40" maxWidth="1000" id="MPF-Mr-zVU">
+                                                <tableColumn width="69" minWidth="40" maxWidth="1000" id="MPF-Mr-zVU">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Hide OSD">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -699,7 +686,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="iWx-Xs-DXV" customClass="HideOsdCellView" customModule="MonitorControl" customModuleProvider="target">
-                                                            <rect key="frame" x="519" y="1" width="68" height="17"/>
+                                                            <rect key="frame" x="519" y="1" width="69" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rW9-Zy-n6z">
@@ -716,6 +703,36 @@
                                                             </subviews>
                                                             <connections>
                                                                 <outlet property="button" destination="rW9-Zy-n6z" id="9JR-jX-ogx"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                                <tableColumn width="86" minWidth="40" maxWidth="1000" id="PaR-Kn-lMO">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Enable Mute">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <customCell key="dataCell" alignment="left" id="xhG-TJ-fnP"/>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="ipA-Or-thd" customClass="EnableMuteCellView" customModule="MonitorControl" customModuleProvider="target">
+                                                            <rect key="frame" x="591" y="1" width="86" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mSt-SG-7e3">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="49" height="18"/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="overlaps" inset="2" id="KkJ-38-KjG">
+                                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="buttonToggled:" target="ipA-Or-thd" id="ynu-WC-IQx"/>
+                                                                    </connections>
+                                                                </button>
+                                                            </subviews>
+                                                            <connections>
+                                                                <outlet property="button" destination="mSt-SG-7e3" id="v0G-2V-VBS"/>
                                                             </connections>
                                                         </tableCellView>
                                                     </prototypeCellViews>
@@ -738,12 +755,12 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <tableHeaderView key="headerView" wantsLayer="YES" id="qVc-cy-LaW">
-                                    <rect key="frame" x="0.0" y="0.0" width="589" height="25"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="679" height="25"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bct-zW-zKf">
-                                <rect key="frame" x="14" y="14" width="145" height="32"/>
+                                <rect key="frame" x="14" y="13" width="151" height="32"/>
                                 <buttonCell key="cell" type="push" title="Reset Preferences" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4Pj-3t-PJr">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -753,10 +770,10 @@
                                 </connections>
                             </button>
                             <stackView distribution="fillProportionally" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VYW-sX-LN2">
-                                <rect key="frame" x="20" y="186" width="589" height="32"/>
+                                <rect key="frame" x="20" y="161" width="679" height="57"/>
                                 <subviews>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Z6T-PG-PcF">
-                                        <rect key="frame" x="-2" y="0.0" width="571" height="32"/>
+                                        <rect key="frame" x="-2" y="13" width="656" height="32"/>
                                         <textFieldCell key="cell" selectable="YES" id="frw-j2-tE1">
                                             <font key="font" metaFont="system"/>
                                             <string key="title">Warning ⚠️
@@ -766,7 +783,7 @@ Changing some of these setting may cause system freezes or unexpected behaviour.
                                         </textFieldCell>
                                     </textField>
                                     <button toolTip="More Info" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kqn-gU-mZX">
-                                        <rect key="frame" x="564" y="2" width="27" height="25"/>
+                                        <rect key="frame" x="650" y="14" width="31" height="25"/>
                                         <buttonCell key="cell" type="help" bezelStyle="helpButton" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="H6v-Sv-5MG">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -808,7 +825,7 @@ Changing some of these setting may cause system freezes or unexpected behaviour.
                 </viewController>
                 <customObject id="lVu-28-yuM" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="379.5" y="554"/>
+            <point key="canvasLocation" x="419" y="554"/>
         </scene>
     </scenes>
 </document>

--- a/MonitorControl/UI/Cells/EnableMuteCellView.swift
+++ b/MonitorControl/UI/Cells/EnableMuteCellView.swift
@@ -1,0 +1,31 @@
+import Cocoa
+import os.log
+
+class EnableMuteCellView: NSTableCellView {
+  @IBOutlet var button: NSButton!
+  var display: ExternalDisplay?
+  let prefs = UserDefaults.standard
+
+  override func draw(_ dirtyRect: NSRect) {
+    super.draw(dirtyRect)
+  }
+
+  @IBAction func buttonToggled(_ sender: NSButton) {
+    if let display = display {
+      switch sender.state {
+      case .on:
+        display.enableMuteUnmute = true
+      case .off:
+        // If the display is currently muted, toggle back to unmute
+        // to prevent the display becoming stuck in the muted state
+        if display.isMuted() {
+          display.toggleMute()
+        }
+
+        display.enableMuteUnmute = false
+      default:
+        break
+      }
+    }
+  }
+}

--- a/MonitorControl/UI/de.lproj/Main.strings
+++ b/MonitorControl/UI/de.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Modell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PZ9-0Z-K6J"; */
 "PZ9-0Z-K6J.title" = "Text Cell";
 

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Model";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PZ9-0Z-K6J"; */
 "PZ9-0Z-K6J.title" = "Text Cell";
 

--- a/MonitorControl/UI/fr.lproj/Main.strings
+++ b/MonitorControl/UI/fr.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Model";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PZ9-0Z-K6J"; */
 "PZ9-0Z-K6J.title" = "Text Cell";
 

--- a/MonitorControl/UI/it.lproj/Main.strings
+++ b/MonitorControl/UI/it.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Modello";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PZ9-0Z-K6J"; */
 "PZ9-0Z-K6J.title" = "Text Cell";
 

--- a/MonitorControl/UI/ja.lproj/Main.strings
+++ b/MonitorControl/UI/ja.lproj/Main.strings
@@ -88,6 +88,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "モデル";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PZ9-0Z-K6J"; */
 "PZ9-0Z-K6J.title" = "Text Cell";
 

--- a/MonitorControl/UI/pl.lproj/Main.strings
+++ b/MonitorControl/UI/pl.lproj/Main.strings
@@ -79,6 +79,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Model";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSMenuItem"; title = "Normal"; ObjectID = "Riq-uM-bTs"; */
 "Riq-uM-bTs.title" = "Normalny";
 

--- a/MonitorControl/UI/ru.lproj/Main.strings
+++ b/MonitorControl/UI/ru.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Модель";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSMenuItem"; title = "Normal"; ObjectID = "Riq-uM-bTs"; */
 "Riq-uM-bTs.title" = "Нормально";
 

--- a/MonitorControl/UI/uk.lproj/Main.strings
+++ b/MonitorControl/UI/uk.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "Модель";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSMenuItem"; title = "Normal"; ObjectID = "Riq-uM-bTs"; */
 "Riq-uM-bTs.title" = "Звич.";
 

--- a/MonitorControl/UI/zh-Hans.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/Main.strings
@@ -76,6 +76,9 @@
 /* Class = "NSTableColumn"; headerCell.title = "Model"; ObjectID = "Nvp-hI-w4x"; */
 "Nvp-hI-w4x.headerCell.title" = "型号";
 
+/* Class = "NSTableColumn"; headerCell.title = "Enable Mute"; ObjectID = "PaR-Kn-lMO"; */
+"PaR-Kn-lMO.headerCell.title" = "Enable Mute";
+
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "PZ9-0Z-K6J"; */
 "PZ9-0Z-K6J.title" = "Text Cell";
 

--- a/MonitorControl/View Controllers/AdvancedPrefsViewController.swift
+++ b/MonitorControl/View Controllers/AdvancedPrefsViewController.swift
@@ -18,6 +18,7 @@ class AdvancedPrefsViewController: NSViewController, MASPreferencesViewControlle
     case pollingCount
     case longerDelay
     case hideOsd
+    case enableMute
   }
 
   @IBOutlet var displayList: NSTableView!
@@ -104,6 +105,12 @@ class AdvancedPrefsViewController: NSViewController, MASPreferencesViewControlle
     case .hideOsd:
       if let cell = tableView.makeView(withIdentifier: tableColumn.identifier, owner: nil) as? HideOsdCellView {
         cell.button.state = display.hideOsd ? .on : .off
+        cell.display = display
+        return cell
+      }
+    case .enableMute:
+      if let cell = tableView.makeView(withIdentifier: tableColumn.identifier, owner: nil) as? EnableMuteCellView {
+        cell.button.state = display.enableMuteUnmute ? .on : .off
         cell.display = display
         return cell
       }


### PR DESCRIPTION
### What Did You Change?
- Added a new preference "Enable Mute" to the Advanced tab of the app's Preferences
- Replaced existing checks for the current display's support for the 0x8D command to use the new "Enable Mute" preference instead

### Why Did You Change It?
This change is a confluence of different issues with volume control and muting:
1. Setting the volume to zero does not mute the sound on some displays (https://github.com/MonitorControl/MonitorControl/issues/94)
2. The 0x8D command (specifically to mute the volume) is not supported at all on some Dell displays (https://github.com/MonitorControl/MonitorControl/issues/107)
3. Support for the 0x8D command is impossible to determine on some LG displays (https://github.com/MonitorControl/MonitorControl/issues/170)

Due to the wonky support for the 0x8D mute command by different displays, and the current inability to identify a universally-applicable pattern that can be applied to automatically determine 0x8D support, this change is necessary to ensure that as many displays as possible can have their volume control and mute/unmute needs met by MonitorControl.

### Screenshots/GIFs
![image](https://user-images.githubusercontent.com/3928269/103179188-291ef900-483e-11eb-81f6-a4ab36f57097.png)

### Potential Risks Introduced
- High production risk - this change will disable the 0x8D command until the preference is enabled (because the default value of the new preference is `off`), which may cause reports similar to https://github.com/MonitorControl/MonitorControl/issues/94
- Medium functional risk - this change introduces another variant to check when the volume control and mute/unmute keys are pressed, and the change can be different per-display

### Testing Steps
- Tested on Samsung C34J79x (mute enabled, mute disabled)
- Tested on an LG 4K display (thanks @riobard)
