### PR TITLE
Fix display names on M1 Macs

### DIFF
--- a/MonitorControl/AppDelegate.swift
+++ b/MonitorControl/AppDelegate.swift
@@ -81,7 +81,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     self.clearDisplays()
 
     for screen in NSScreen.screens {
-      let name = screen.displayName ?? NSLocalizedString("Unknown", comment: "Unknown display name")
+      let name: String
+      if #available(OSX 10.15, *) {
+        name = screen.localizedName
+      } else {
+        name = screen.displayName ?? NSLocalizedString("Unknown", comment: "Unknown display name")
+      }
       let id = screen.displayID
       let vendorNumber = screen.vendorNumber
       let modelNumber = screen.modelNumber


### PR DESCRIPTION
Starting with Catalina there is a `localizedName` property that can be used to get the name of the display. The old way doesn't work at all on the new M1 based Macs, so this also fixes the name on those computers.

Note that this doesn't give us compatibility with M1 Macs, it's just one small step in that direction.

related: #323 