### PR TITLE
Update OpenCollective link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-open_collective: monitorcontrol/donate
+open_collective: monitorcontrol


### PR DESCRIPTION
Change the OpenCollective link to go the main page rather than the donate action