### PR TITLE
Add direct link to monitor troubleshooting wiki for monitor issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/monitor-issue.yml
+++ b/.github/ISSUE_TEMPLATE/monitor-issue.yml
@@ -10,7 +10,7 @@ body:
       options:
         - label: Searched for existing issues
           required: true
-        - label: Looked through [the wiki](https://github.com/MonitorControl/MonitorControl/wiki)
+        - label: I have read through [the Monitor-Troubleshooting Wiki](https://github.com/MonitorControl/MonitorControl/wiki/Monitor-Troubleshooting)
           required: true
         - label: Updated MonitorControl to the latest version (if applicable)
           required: true


### PR DESCRIPTION
Minor change to directly refer to troubleshooting wiki, seems like a more logical link there