### PR TITLE
feat: close preference pane using cmd + w

### DIFF
--- a/MonitorControl/Extensions/Preferences+Extension.swift
+++ b/MonitorControl/Extensions/Preferences+Extension.swift
@@ -1,5 +1,7 @@
 //  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
 
+import Cocoa
+
 import Preferences
 
 extension Preferences.PaneIdentifier {
@@ -8,4 +10,14 @@ extension Preferences.PaneIdentifier {
   static let keyboard = Self("Keyboard")
   static let displays = Self("Displays")
   static let about = Self("About")
+}
+
+public extension PreferencesWindowController {
+  override func keyDown(with event: NSEvent) {
+    if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command, let key = event.charactersIgnoringModifiers {
+      if key == "w" {
+        self.close()
+      }
+    }
+  }
 }

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6293</string>
+	<string>6295</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6293</string>
+	<string>6295</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
closes #639 

This implements the ability to close the preferences pane using <kbd>command</kbd> + <kbd>w</kbd>

I looked around at which shortcuts other applications with similar Preference system listened to (Vimac and system prefs for example) and decided that <kbd>command</kbd> + <kbd>w</kbd> made most sense. Feel free to correct me or suggest other combinations. 

I didn't manage to get <kbd>esc</kbd> to work, that usually requires implementing `cancelOperation`, perhaps the window doesn't have proper focus or something else is wrong. Though I didn't notice any other apps listening to escape either so maybe we shouldn't do it as to not deviate from "the standard".

Another thing to note: If you were to assign <kbd>command</kbd> + <kbd>w</kbd> to a MonitorControl shortcut, that would take priority, which makes sense imo.