### PR TITLE
Some minor fixes and changes

### DIFF
--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		AA5314C426EBF5170041D178 /* PrefKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5314C326EBF5170041D178 /* PrefKey.swift */; };
 		AA665A5D26C5892800FEF2C1 /* AboutPrefsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA665A5C26C5892800FEF2C1 /* AboutPrefsViewController.swift */; };
 		AA70817C27046B9800CC5625 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = AA70817B27046B9800CC5625 /* Sparkle */; };
+		AA78BDBD2709FE7B00CA8DF7 /* UpdaterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA78BDBC2709FE7B00CA8DF7 /* UpdaterDelegate.swift */; };
 		AA99521726FE25AB00612E07 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA99521626FE25AB00612E07 /* AppDelegate.swift */; };
 		AA99521926FE49A300612E07 /* MenuHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA99521826FE49A300612E07 /* MenuHandler.swift */; };
 		AA9AE86F26B5BF3D00B6CA65 /* OSD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA9AE86E26B5BF3D00B6CA65 /* OSD.framework */; };
@@ -106,6 +107,7 @@
 		AA473EB026DFF8DE0063A181 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AA5314C326EBF5170041D178 /* PrefKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefKey.swift; sourceTree = "<group>"; };
 		AA665A5C26C5892800FEF2C1 /* AboutPrefsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutPrefsViewController.swift; sourceTree = "<group>"; };
+		AA78BDBC2709FE7B00CA8DF7 /* UpdaterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterDelegate.swift; sourceTree = "<group>"; };
 		AA99521626FE25AB00612E07 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AA99521826FE49A300612E07 /* MenuHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuHandler.swift; sourceTree = "<group>"; };
 		AA9AE86E26B5BF3D00B6CA65 /* OSD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSD.framework; path = ../../../../../System/Library/PrivateFrameworks/OSD.framework; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 			children = (
 				F01B0685228221B6008E64DB /* Bridging-Header.h */,
 				AA99521626FE25AB00612E07 /* AppDelegate.swift */,
+				AA78BDBC2709FE7B00CA8DF7 /* UpdaterDelegate.swift */,
 				AA99521826FE49A300612E07 /* MenuHandler.swift */,
 				F01B068F228221B7008E64DB /* SliderHandler.swift */,
 				6C85EFD922C941B000227EA1 /* DisplayManager.swift */,
@@ -552,6 +555,7 @@
 				6CBFE27A23DB266000D1BC41 /* Display.swift in Sources */,
 				AA44E70727038F7F00E06865 /* KeyboardShortcutsManager.swift in Sources */,
 				F03A8DF21FFBAA6F0034DC27 /* OtherDisplay.swift in Sources */,
+				AA78BDBD2709FE7B00CA8DF7 /* UpdaterDelegate.swift in Sources */,
 				AA44E7052703790100E06865 /* KeyboardShortcuts+Extension.swift in Sources */,
 				AA16139B26BE772E00DCF027 /* Arm64DDC.swift in Sources */,
 				F0445D3820023E710025AE82 /* MainPrefsViewController.swift in Sources */,

--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -7,6 +7,9 @@ enum PrefKey: String {
   // Sparkle automatic checks
   case SUEnableAutomaticChecks
 
+  // Receive beta updates?
+  case isBetaChannel // This is not added to Preferences yet as it will be needed in the future only.
+
   // Hide OSD for display
   case hideOsd
 

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6314</string>
+	<string>6322</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6307</string>
+	<string>6314</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6322</string>
+	<string>6350</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6350</string>
+	<string>6359</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6359</string>
+	<string>6370</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6370</string>
+	<string>6389</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6389</string>
+	<string>6390</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Support/AppDelegate.swift
+++ b/MonitorControl/Support/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   var sleepID: Int = 0 // sleep event ID
   var safeMode = false
   var jobRunning = false
-  let updaterController = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil)
+  let updaterController = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: UpdaterDelegate(), userDriverDelegate: nil)
 
   var preferencePaneStyle: Preferences.Style {
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -91,7 +91,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
     if numOfDisplays > 1, !prefs.bool(forKey: PrefKey.slidersRelevant.rawValue), !DEBUG_MACOS10, #available(macOS 11.0, *) {
       class BlockView: NSView {
         override func draw(_: NSRect) {
-          let radius = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? CGFloat(6) : CGFloat(11)
+          let radius = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? CGFloat(4) : CGFloat(11)
           let outerMargin = CGFloat(15)
           let blockRect = self.frame.insetBy(dx: outerMargin, dy: outerMargin / 2 + 2).offsetBy(dx: 0, dy: outerMargin / 2 * -1 + 7)
           for i in 1 ... 5 {
@@ -234,8 +234,10 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       updateIcon.bezelStyle = .regularSquare
       updateIcon.isBordered = false
       updateIcon.setButtonType(.momentaryChange)
-      updateIcon.image = NSImage(systemSymbolName: "arrow.triangle.2.circlepath.circle", accessibilityDescription: NSLocalizedString("Check for updates...", comment: "Shown in menu"))
-      updateIcon.alternateImage = NSImage(systemSymbolName: "arrow.triangle.2.circlepath.circle.fill", accessibilityDescription: NSLocalizedString("Check for updates...", comment: "Shown in menu"))
+      var symbolName = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? "arrow.left.arrow.right.square" : "arrow.triangle.2.circlepath.circle"
+      updateIcon.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: NSLocalizedString("Check for updates...", comment: "Shown in menu"))
+      updateIcon.alternateImage = NSImage(systemSymbolName: symbolName + ".fill", accessibilityDescription: NSLocalizedString("Check for updates...", comment: "Shown in menu"))
+
       updateIcon.alphaValue = 0.3
       updateIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize * 2 - 20 - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
       updateIcon.imageScaling = .scaleProportionallyUpOrDown
@@ -246,8 +248,9 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       quitIcon.bezelStyle = .regularSquare
       quitIcon.isBordered = false
       quitIcon.setButtonType(.momentaryChange)
-      quitIcon.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: NSLocalizedString("Quit", comment: "Shown in menu"))
-      quitIcon.alternateImage = NSImage(systemSymbolName: "xmark.circle.fill", accessibilityDescription: NSLocalizedString("Quit", comment: "Shown in menu"))
+      symbolName = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? "multiply.square" : "xmark.circle"
+      quitIcon.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: NSLocalizedString("Quit", comment: "Shown in menu"))
+      quitIcon.alternateImage = NSImage(systemSymbolName: symbolName + ".fill", accessibilityDescription: NSLocalizedString("Quit", comment: "Shown in menu"))
       quitIcon.alphaValue = 0.3
       quitIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize * 3 - 30 - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
       quitIcon.imageScaling = .scaleProportionallyUpOrDown

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -211,7 +211,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
   func addDefaultMenuOptions() {
     if !DEBUG_MACOS10, #available(macOS 11.0, *), prefs.integer(forKey: PrefKey.menuItemStyle.rawValue) == MenuItemStyle.icon.rawValue {
       let iconSize = CGFloat(22)
-      let viewWidth = max(120, self.size.width)
+      let viewWidth = max(130, self.size.width)
       var compensateForBlock: CGFloat = 0
       if viewWidth > 230 { // if there are display blocks, we need to compensate a bit for the negative inset of the blocks
         compensateForBlock = 4
@@ -223,8 +223,13 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       preferencesIcon.bezelStyle = .regularSquare
       preferencesIcon.isBordered = false
       preferencesIcon.setButtonType(.momentaryChange)
-      preferencesIcon.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
-      preferencesIcon.alternateImage = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
+      if #available(macOS 12.0, *) {
+        preferencesIcon.image = NSImage(systemSymbolName: "gearshape.circle", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
+        preferencesIcon.alternateImage = NSImage(systemSymbolName: "gearshape.circle.fill", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
+      } else {
+        preferencesIcon.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
+        preferencesIcon.alternateImage = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
+      }
       preferencesIcon.alphaValue = 0.3
       preferencesIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
       preferencesIcon.imageScaling = .scaleProportionallyUpOrDown
@@ -237,7 +242,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       updateIcon.image = NSImage(systemSymbolName: "arrow.triangle.2.circlepath.circle", accessibilityDescription: NSLocalizedString("Check for updates...", comment: "Shown in menu"))
       updateIcon.alternateImage = NSImage(systemSymbolName: "arrow.triangle.2.circlepath.circle.fill", accessibilityDescription: NSLocalizedString("Check for updates...", comment: "Shown in menu"))
       updateIcon.alphaValue = 0.3
-      updateIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize * 2 - 10 - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
+      updateIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize * 2 - 20 - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
       updateIcon.imageScaling = .scaleProportionallyUpOrDown
       updateIcon.action = #selector(app.updaterController.checkForUpdates(_:))
       updateIcon.target = app.updaterController
@@ -249,7 +254,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       quitIcon.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: NSLocalizedString("Quit", comment: "Shown in menu"))
       quitIcon.alternateImage = NSImage(systemSymbolName: "xmark.circle.fill", accessibilityDescription: NSLocalizedString("Quit", comment: "Shown in menu"))
       quitIcon.alphaValue = 0.3
-      quitIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize * 3 - 20 - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
+      quitIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize * 3 - 30 - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
       quitIcon.imageScaling = .scaleProportionallyUpOrDown
       quitIcon.action = #selector(app.quitClicked)
 

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -267,7 +267,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       let updateItem = NSMenuItem(title: NSLocalizedString("Check for updates...", comment: "Shown in menu"), action: #selector(app.updaterController.checkForUpdates(_:)), keyEquivalent: "")
       updateItem.target = app.updaterController
       self.insertItem(updateItem, at: self.items.count)
-      self.insertItem(withTitle: NSLocalizedString("Quit", comment: "Shown in menu"), action: #selector(app.quitClicked), keyEquivalent: "", at: self.items.count)
+      self.insertItem(withTitle: NSLocalizedString("Quit", comment: "Shown in menu"), action: #selector(app.quitClicked), keyEquivalent: "q", at: self.items.count)
     }
   }
 }

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -91,7 +91,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
     if numOfDisplays > 1, !prefs.bool(forKey: PrefKey.slidersRelevant.rawValue), !DEBUG_MACOS10, #available(macOS 11.0, *) {
       class BlockView: NSView {
         override func draw(_: NSRect) {
-          let radius = CGFloat(11)
+          let radius = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? CGFloat(6) : CGFloat(11)
           let outerMargin = CGFloat(15)
           let blockRect = self.frame.insetBy(dx: outerMargin, dy: outerMargin / 2 + 2).offsetBy(dx: 0, dy: outerMargin / 2 * -1 + 7)
           for i in 1 ... 5 {

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -223,13 +223,8 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       preferencesIcon.bezelStyle = .regularSquare
       preferencesIcon.isBordered = false
       preferencesIcon.setButtonType(.momentaryChange)
-      if #available(macOS 12.0, *) {
-        preferencesIcon.image = NSImage(systemSymbolName: "gearshape.circle", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
-        preferencesIcon.alternateImage = NSImage(systemSymbolName: "gearshape.circle.fill", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
-      } else {
-        preferencesIcon.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
-        preferencesIcon.alternateImage = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
-      }
+      preferencesIcon.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
+      preferencesIcon.alternateImage = NSImage(systemSymbolName: "gearshape.fill", accessibilityDescription: NSLocalizedString("Preferences...", comment: "Shown in menu"))
       preferencesIcon.alphaValue = 0.3
       preferencesIcon.frame = NSRect(x: menuItemView.frame.maxX - iconSize - 16 + compensateForBlock, y: menuItemView.frame.origin.y + 5, width: iconSize, height: iconSize)
       preferencesIcon.imageScaling = .scaleProportionallyUpOrDown

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -29,7 +29,7 @@ class SliderHandler {
     let offsetY: CGFloat = -1.5
 
     let tickMarkKnobExtraInset: CGFloat = 4
-    let tickMarkKnobExtraRadiusMultiplier: CGFloat = 0.5
+    let tickMarkKnobExtraRadiusMultiplier: CGFloat = 0.25
 
     var numOfTickmarks: Int = 0
     var isHighlightDisplayItems: Bool = false
@@ -102,7 +102,7 @@ class SliderHandler {
         for i in 1 ... self.numOfTickmarks - 2 {
           let currentMarkLocation = CGFloat((Float(1) / Float(self.numOfTickmarks - 1)) * Float(i))
           let tickMarkBounds = NSRect(x: aRect.origin.x + aRect.height + self.tickMarkKnobExtraInset - knobRect.height + self.tickMarkKnobExtraInset * 2 + CGFloat(Float((aRect.width - self.tickMarkKnobExtraInset * 5) * currentMarkLocation)), y: aRect.origin.y + aRect.height * (1 / 3), width: 4, height: aRect.height / 3)
-          let tickmark = NSBezierPath(roundedRect: tickMarkBounds, xRadius: 2, yRadius: 2)
+          let tickmark = NSBezierPath(roundedRect: tickMarkBounds, xRadius: 1, yRadius: 1)
           self.tickMarkColor.setFill()
           tickmark.fill()
         }

--- a/MonitorControl/Support/UpdaterDelegate.swift
+++ b/MonitorControl/Support/UpdaterDelegate.swift
@@ -1,0 +1,10 @@
+//  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+
+import Foundation
+import Sparkle
+
+class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+  func allowedChannels(for _: SPUUpdater) -> Set<String> {
+    return prefs.bool(forKey: PrefKey.isBetaChannel.rawValue) ? Set(["beta"]) : Set([])
+  }
+}

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -11,10 +11,10 @@
             <objects>
                 <viewController storyboardIdentifier="MainPrefsVC" id="BGD-tY-Myx" customClass="MainPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" horizontalHuggingPriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="COE-Oc-gZs">
-                        <rect key="frame" x="0.0" y="0.0" width="691" height="605"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="605"/>
                         <subviews>
                             <gridView xPlacement="leading" yPlacement="fill" rowAlignment="none" rowSpacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="noT-gJ-0yS">
-                                <rect key="frame" x="20" y="20" width="651" height="565"/>
+                                <rect key="frame" x="20" y="20" width="690" height="565"/>
                                 <rows>
                                     <gridRow bottomPadding="-6" id="d70-FX-dma"/>
                                     <gridRow bottomPadding="-10" id="hdq-3y-aue"/>
@@ -41,13 +41,13 @@
                                     <gridRow id="1zL-Fy-6VV"/>
                                 </rows>
                                 <columns>
-                                    <gridColumn width="226" id="eHC-Ur-UsS"/>
-                                    <gridColumn xPlacement="fill" width="414" leadingPadding="5" id="64O-72-10l"/>
+                                    <gridColumn width="210" id="eHC-Ur-UsS"/>
+                                    <gridColumn xPlacement="fill" width="470" leadingPadding="4" id="64O-72-10l"/>
                                 </columns>
                                 <gridCells>
                                     <gridCell row="d70-FX-dma" column="eHC-Ur-UsS" xPlacement="trailing" id="ixb-6N-RsC">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HkH-iv-GLz">
-                                            <rect key="frame" x="152" y="549" width="76" height="16"/>
+                                            <rect key="frame" x="136" y="549" width="76" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" baseWritingDirection="leftToRight" alignment="right" title="Application:" id="okD-DG-pYa">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -57,7 +57,7 @@
                                     </gridCell>
                                     <gridCell row="d70-FX-dma" column="64O-72-10l" xPlacement="leading" id="v0S-4P-60y">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Gu-aU-Td2">
-                                            <rect key="frame" x="235" y="548" width="108" height="18"/>
+                                            <rect key="frame" x="218" y="548" width="108" height="18"/>
                                             <buttonCell key="cell" type="check" title="Start at Login" bezelStyle="regularSquare" imagePosition="left" inset="2" id="j72-NF-zsW">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -70,7 +70,7 @@
                                     <gridCell row="hdq-3y-aue" column="eHC-Ur-UsS" id="gY2-G1-Lxs"/>
                                     <gridCell row="hdq-3y-aue" column="64O-72-10l" id="q9Q-Sd-a4F">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="79h-9d-Iwx">
-                                            <rect key="frame" x="235" y="518" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="518" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Automatically check for updates" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Faf-9L-TXx">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -81,14 +81,14 @@
                                         </button>
                                     </gridCell>
                                     <gridCell row="CrM-x5-re7" column="eHC-Ur-UsS" headOfMergedCell="UBc-A2-Il4" id="UBc-A2-Il4">
-                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="YEg-U6-LH4">
-                                            <rect key="frame" x="0.0" y="505" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="YEg-U6-LH4">
+                                            <rect key="frame" x="0.0" y="505" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="CrM-x5-re7" column="64O-72-10l" headOfMergedCell="UBc-A2-Il4" id="s0l-Gz-1c0"/>
                                     <gridCell row="DnA-aR-kcy" column="eHC-Ur-UsS" xPlacement="trailing" id="vO3-t1-Aqs">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vsD-wo-GE1">
-                                            <rect key="frame" x="124" y="481" width="104" height="16"/>
+                                            <rect key="frame" x="108" y="481" width="104" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="General options:" id="W58-ch-j69">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -98,7 +98,7 @@
                                     </gridCell>
                                     <gridCell row="DnA-aR-kcy" column="64O-72-10l" id="Srb-mF-ZHj">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7cl-Ma-fc4">
-                                            <rect key="frame" x="235" y="480" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="480" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Enable smooth brightness transitions" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="IK4-u5-qjf">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -111,7 +111,7 @@
                                     <gridCell row="xlB-05-nd7" column="eHC-Ur-UsS" id="A6K-rU-q8d"/>
                                     <gridCell row="xlB-05-nd7" column="64O-72-10l" id="3by-qE-2cw">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="E8S-HE-vSk">
-                                            <rect key="frame" x="235" y="460" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="460" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="You can disable smooth transitions for a more direct, immediate control." id="ENt-mP-0yH">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -122,7 +122,7 @@
                                     <gridCell row="fnu-hr-lg2" column="eHC-Ur-UsS" xPlacement="trailing" id="7Br-bw-2Th"/>
                                     <gridCell row="fnu-hr-lg2" column="64O-72-10l" xPlacement="leading" id="VsI-fh-hJ5">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HqE-17-9wg">
-                                            <rect key="frame" x="235" y="433" width="278" height="18"/>
+                                            <rect key="frame" x="218" y="433" width="278" height="18"/>
                                             <buttonCell key="cell" type="check" title="Combine hardware and software dimming" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="r76-Zc-x09">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -135,7 +135,7 @@
                                     <gridCell row="fZn-VF-HKh" column="eHC-Ur-UsS" xPlacement="trailing" id="4xt-0S-gdo"/>
                                     <gridCell row="fZn-VF-HKh" column="64O-72-10l" xPlacement="leading" id="CMT-YB-Lnh">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="cSz-6K-c2a">
-                                            <rect key="frame" x="235" y="399" width="395" height="28"/>
+                                            <rect key="frame" x="218" y="399" width="395" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="PyY-p9-3NP">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Use software dimming after the display reached zero hardware brightness for extended range. Works for DDC controlled displays only.</string>
@@ -147,7 +147,7 @@
                                     <gridCell row="xKQ-LY-5il" column="eHC-Ur-UsS" id="5Ae-gB-MUt"/>
                                     <gridCell row="xKQ-LY-5il" column="64O-72-10l" id="Rzu-9I-Tog">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DW6-ez-A8y">
-                                            <rect key="frame" x="235" y="372" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="372" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Sync brightness changes from Built-in and Apple displays" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="0ca-DG-AgB">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -160,7 +160,7 @@
                                     <gridCell row="jHJ-o2-Y9H" column="eHC-Ur-UsS" id="En7-LK-oWB"/>
                                     <gridCell row="jHJ-o2-Y9H" column="64O-72-10l" id="wYJ-EG-TWv">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="gLU-8p-2gU">
-                                            <rect key="frame" x="235" y="338" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="338" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="wjv-tq-iUx">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Changes that are caused by the Ambient light sensor or made using Touch Bar, Control Center, System Preferences will be replicated to all displays.</string>
@@ -172,7 +172,7 @@
                                     <gridCell row="Ypu-QY-Cja" column="eHC-Ur-UsS" id="IhV-pU-vai"/>
                                     <gridCell row="Ypu-QY-Cja" column="64O-72-10l" id="UmJ-Q7-F5C">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rdj-ft-rJg">
-                                            <rect key="frame" x="235" y="311" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="311" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Disable software dimming as fallback" bezelStyle="regularSquare" imagePosition="left" inset="2" id="afB-Xx-Lta">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -185,7 +185,7 @@
                                     <gridCell row="jUq-ZO-OLV" column="eHC-Ur-UsS" id="qIZ-c7-Usj"/>
                                     <gridCell row="jUq-ZO-OLV" column="64O-72-10l" id="rc0-is-gD8">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kre-Lm-1Uv">
-                                            <rect key="frame" x="235" y="291" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="291" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Don't use software dimming as fallback if no hardware control is available." id="kgh-b4-gmO">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -194,14 +194,14 @@
                                         </textField>
                                     </gridCell>
                                     <gridCell row="gGa-4U-s7D" column="eHC-Ur-UsS" headOfMergedCell="hH2-hj-VXr" id="hH2-hj-VXr">
-                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zA4-hk-MYo">
-                                            <rect key="frame" x="0.0" y="277" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zA4-hk-MYo">
+                                            <rect key="frame" x="0.0" y="277" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="gGa-4U-s7D" column="64O-72-10l" headOfMergedCell="hH2-hj-VXr" id="dEl-GK-ctf"/>
                                     <gridCell row="g3B-cE-vmT" column="eHC-Ur-UsS" xPlacement="trailing" id="tAh-1B-VfM">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fTf-gB-8JX">
-                                            <rect key="frame" x="90" y="253" width="138" height="16"/>
+                                            <rect key="frame" x="74" y="253" width="138" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Upon startup or wake:" id="cNt-Cq-vK4">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -211,7 +211,7 @@
                                     </gridCell>
                                     <gridCell row="g3B-cE-vmT" column="64O-72-10l" xPlacement="leading" id="eYR-Th-VbP">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mus-cc-See">
-                                            <rect key="frame" x="235" y="252" width="346" height="18"/>
+                                            <rect key="frame" x="218" y="252" width="346" height="18"/>
                                             <buttonCell key="cell" type="radio" title="Assume last saved settings are valid (recommended)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="yn8-Nd-o89">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -224,7 +224,7 @@
                                     <gridCell row="0ue-QI-RgH" column="eHC-Ur-UsS" id="Sm5-Fc-F4S"/>
                                     <gridCell row="0ue-QI-RgH" column="64O-72-10l" id="S8M-Pw-kzT">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="8Fm-VA-5sp">
-                                            <rect key="frame" x="235" y="218" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="218" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="an7-Aj-3fZ">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Use brightness, volume and other settings from last time or use defaults. Values will be applied to the display upon first change by the user.</string>
@@ -236,7 +236,7 @@
                                     <gridCell row="3et-Li-HBw" column="eHC-Ur-UsS" id="heh-Xy-qJS"/>
                                     <gridCell row="3et-Li-HBw" column="64O-72-10l" id="KdS-No-dJl">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AjD-Oy-S0f">
-                                            <rect key="frame" x="235" y="191" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="191" width="472" height="18"/>
                                             <buttonCell key="cell" type="radio" title="Apply last saved values to the display" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="K0S-zN-M4k">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -249,7 +249,7 @@
                                     <gridCell row="zBq-qo-TWc" column="eHC-Ur-UsS" id="SU4-XF-LDb"/>
                                     <gridCell row="zBq-qo-TWc" column="64O-72-10l" id="ChQ-LM-JbZ">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="cwW-VH-Nqj">
-                                            <rect key="frame" x="235" y="171" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="171" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Useful when a display tends to reset its settings during sleep." id="w8B-x6-sq5">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -260,7 +260,7 @@
                                     <gridCell row="tGg-mO-YiD" column="eHC-Ur-UsS" id="My8-pJ-kb1"/>
                                     <gridCell row="tGg-mO-YiD" column="64O-72-10l" id="Gdm-K9-Mzv">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5M2-Ww-w0G">
-                                            <rect key="frame" x="235" y="144" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="144" width="472" height="18"/>
                                             <buttonCell key="cell" type="radio" title="Attempt to read display settings" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="0qp-fq-8MI">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -273,7 +273,7 @@
                                     <gridCell row="UAP-kZ-c0z" column="eHC-Ur-UsS" id="AX0-yT-SVr"/>
                                     <gridCell row="UAP-kZ-c0z" column="64O-72-10l" id="w1F-2K-Kmv">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="uVw-0p-A1a">
-                                            <rect key="frame" x="235" y="124" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="124" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Update settings from the display. May not work with some hardware." id="xjq-hs-wWB">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -284,7 +284,7 @@
                                     <gridCell row="pdf-bY-bem" column="eHC-Ur-UsS" id="gXT-YP-g9t"/>
                                     <gridCell row="pdf-bY-bem" column="64O-72-10l" id="YZY-lB-DKx">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="frx-bK-t8V">
-                                            <rect key="frame" x="235" y="89" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="89" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" title="Note: you can press Shift during startup for 'Safe mode' to restore defaults and avoid reading or setting anything." id="Jx2-gO-nq9">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -293,14 +293,14 @@
                                         </textField>
                                     </gridCell>
                                     <gridCell row="ALY-LA-2OR" column="eHC-Ur-UsS" headOfMergedCell="cRV-TN-DdK" id="cRV-TN-DdK">
-                                        <box key="contentView" autoresizesSubviews="NO" verticalHuggingPriority="750" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="7cE-3n-7fu">
-                                            <rect key="frame" x="0.0" y="75" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" verticalHuggingPriority="750" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="7cE-3n-7fu">
+                                            <rect key="frame" x="0.0" y="75" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="ALY-LA-2OR" column="64O-72-10l" headOfMergedCell="cRV-TN-DdK" id="r3r-m7-Zcs"/>
                                     <gridCell row="cOB-Hr-kYl" column="eHC-Ur-UsS" xPlacement="trailing" id="2ao-6c-6bc">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GPV-cW-Jjc">
-                                            <rect key="frame" x="160" y="51" width="68" height="16"/>
+                                            <rect key="frame" x="144" y="51" width="68" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Advanced:" id="r7i-oG-Ab6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -310,7 +310,7 @@
                                     </gridCell>
                                     <gridCell row="cOB-Hr-kYl" column="64O-72-10l" xPlacement="leading" id="7rF-ux-Tch">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1Jz-FP-0Vl">
-                                            <rect key="frame" x="235" y="50" width="174" height="18"/>
+                                            <rect key="frame" x="218" y="50" width="174" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show advanced settings" bezelStyle="regularSquare" imagePosition="left" inset="2" id="sAR-sh-y8e">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -324,7 +324,7 @@
                                     <gridCell row="IGD-qM-G0J" column="eHC-Ur-UsS" id="voj-wm-FXL"/>
                                     <gridCell row="IGD-qM-G0J" column="64O-72-10l" id="fwc-7b-SnU">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="0dg-F6-di1">
-                                            <rect key="frame" x="235" y="30" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="30" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Display advanced settings and additional information in Preferences." id="X6w-Ee-9Jq">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -335,7 +335,7 @@
                                     <gridCell row="1zL-Fy-6VV" column="eHC-Ur-UsS" id="ZXq-MT-yta"/>
                                     <gridCell row="1zL-Fy-6VV" column="64O-72-10l" xPlacement="leading" id="LYo-2f-Lll">
                                         <button key="contentView" verticalHuggingPriority="750" placeholderIntrinsicWidth="200" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="s9H-FF-JCT">
-                                            <rect key="frame" x="230" y="-7" width="214" height="32"/>
+                                            <rect key="frame" x="213" y="-7" width="214" height="32"/>
                                             <buttonCell key="cell" type="push" title="Reset Preferences" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5yT-5F-X5R">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -382,17 +382,17 @@
                 </viewController>
                 <customObject id="JDw-du-OST" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="300.5" y="-500.5"/>
+            <point key="canvasLocation" x="298" y="-500.5"/>
         </scene>
         <!--Menusliders Prefs View Controller-->
         <scene sceneID="YU5-7I-f0n">
             <objects>
                 <viewController storyboardIdentifier="MenuslidersPrefsVC" id="tLm-u5-aZ2" customClass="MenuslidersPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="5un-m0-FM4">
-                        <rect key="frame" x="0.0" y="0.0" width="691" height="632"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="632"/>
                         <subviews>
                             <gridView xPlacement="leading" yPlacement="fill" rowAlignment="none" rowSpacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ZrF-7t-BP5">
-                                <rect key="frame" x="20" y="20" width="651" height="592"/>
+                                <rect key="frame" x="20" y="20" width="690" height="592"/>
                                 <rows>
                                     <gridRow height="20" bottomPadding="-6" id="jyr-gk-BEN"/>
                                     <gridRow height="20" bottomPadding="-6" id="ZS3-Gy-pfA"/>
@@ -421,13 +421,13 @@
                                     <gridRow id="fDY-kq-bjz"/>
                                 </rows>
                                 <columns>
-                                    <gridColumn width="226" id="FRJ-Rb-RRh"/>
-                                    <gridColumn xPlacement="fill" width="414" leadingPadding="5" id="V6M-Jv-Agj"/>
+                                    <gridColumn width="210" id="FRJ-Rb-RRh"/>
+                                    <gridColumn xPlacement="fill" width="470" leadingPadding="4" id="V6M-Jv-Agj"/>
                                 </columns>
                                 <gridCells>
                                     <gridCell row="jyr-gk-BEN" column="FRJ-Rb-RRh" xPlacement="trailing" id="vn6-rs-m8R">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ELU-jk-ITc">
-                                            <rect key="frame" x="157" y="572" width="71" height="20"/>
+                                            <rect key="frame" x="141" y="572" width="71" height="20"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" baseWritingDirection="leftToRight" alignment="right" title="Menu Icon:" id="u6s-Pb-BCG">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -437,7 +437,7 @@
                                     </gridCell>
                                     <gridCell row="jyr-gk-BEN" column="V6M-Jv-Agj" xPlacement="leading" id="wUb-Z3-UWb">
                                         <popUpButton key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TFy-Wt-ZJK">
-                                            <rect key="frame" x="234" y="568" width="252" height="25"/>
+                                            <rect key="frame" x="217" y="568" width="252" height="25"/>
                                             <popUpButtonCell key="cell" type="push" title="Always show in the menu bar" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="MM0-Lf-VgF" id="p9E-Ck-YKe">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="menu"/>
@@ -456,7 +456,7 @@
                                     </gridCell>
                                     <gridCell row="ZS3-Gy-pfA" column="FRJ-Rb-RRh" xPlacement="trailing" id="6xd-Be-tsQ">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="phO-ae-q58">
-                                            <rect key="frame" x="66" y="538" width="162" height="20"/>
+                                            <rect key="frame" x="50" y="538" width="162" height="20"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" baseWritingDirection="leftToRight" alignment="right" title="General menu items style:" id="thh-DG-ecH">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -466,7 +466,7 @@
                                     </gridCell>
                                     <gridCell row="ZS3-Gy-pfA" column="V6M-Jv-Agj" xPlacement="leading" id="QXg-i0-lVT">
                                         <popUpButton key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6td-Zq-3e7">
-                                            <rect key="frame" x="234" y="534" width="126" height="25"/>
+                                            <rect key="frame" x="217" y="534" width="126" height="25"/>
                                             <popUpButtonCell key="cell" type="push" title="Show as text" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="fWd-Es-zsy" id="2lO-tb-DFv">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="menu"/>
@@ -486,7 +486,7 @@
                                     <gridCell row="OpF-3Q-ZZp" column="FRJ-Rb-RRh" xPlacement="trailing" id="nsg-IK-UoL"/>
                                     <gridCell row="OpF-3Q-ZZp" column="V6M-Jv-Agj" xPlacement="leading" id="9Au-qH-WOr">
                                         <button key="contentView" verticalHuggingPriority="750" placeholderIntrinsicWidth="150" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="dy4-nH-cIr">
-                                            <rect key="frame" x="230" y="497" width="164" height="32"/>
+                                            <rect key="frame" x="213" y="497" width="164" height="32"/>
                                             <buttonCell key="cell" type="push" title="Quit application" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="qlb-wH-qr4">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -499,7 +499,7 @@
                                     <gridCell row="HAl-L8-LPI" column="FRJ-Rb-RRh" id="ulS-1p-gHw"/>
                                     <gridCell row="HAl-L8-LPI" column="V6M-Jv-Agj" xPlacement="leading" id="tw2-81-sd0">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OmW-TV-zvg">
-                                            <rect key="frame" x="235" y="469" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="469" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" title="Relaunch the app to access Preferences if the menu option is not accessible. Use the button below to quit the app." id="hF7-fM-aKr">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -508,14 +508,14 @@
                                         </textField>
                                     </gridCell>
                                     <gridCell row="Cor-61-8R5" column="FRJ-Rb-RRh" headOfMergedCell="054-Ho-JWX" id="054-Ho-JWX">
-                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="jt4-ec-HMg">
-                                            <rect key="frame" x="0.0" y="458" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="jt4-ec-HMg">
+                                            <rect key="frame" x="0.0" y="458" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="Cor-61-8R5" column="V6M-Jv-Agj" headOfMergedCell="054-Ho-JWX" id="qgh-h4-pBB"/>
                                     <gridCell row="x3R-eu-dsV" column="FRJ-Rb-RRh" xPlacement="trailing" id="ncF-aj-FmT">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="T3u-43-BPw">
-                                            <rect key="frame" x="109" y="434" width="119" height="16"/>
+                                            <rect key="frame" x="93" y="434" width="119" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Brightness control:" id="fe9-Ia-t9m">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -525,7 +525,7 @@
                                     </gridCell>
                                     <gridCell row="x3R-eu-dsV" column="V6M-Jv-Agj" id="wTq-1M-KT4">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NaD-fA-S7k">
-                                            <rect key="frame" x="235" y="433" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="433" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show brightness slider in menu" bezelStyle="regularSquare" imagePosition="left" inset="2" id="MWo-6I-s9L">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -538,7 +538,7 @@
                                     <gridCell row="dyb-Ub-uU5" column="FRJ-Rb-RRh" id="cLJ-BF-5vS"/>
                                     <gridCell row="dyb-Ub-uU5" column="V6M-Jv-Agj" id="XhS-WT-EqK">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-q1-pFA">
-                                            <rect key="frame" x="235" y="413" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="413" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Brightness slider for hardware or software controlled displays or TVs." id="gXH-HL-ZOL">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -549,7 +549,7 @@
                                     <gridCell row="oLy-ZP-OiA" column="FRJ-Rb-RRh" id="cAk-q3-3t5"/>
                                     <gridCell row="oLy-ZP-OiA" column="V6M-Jv-Agj" id="tcL-q6-Twk">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jnZ-Nf-GaQ">
-                                            <rect key="frame" x="235" y="386" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="386" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Enable for Apple branded and built-in displays as well" bezelStyle="regularSquare" imagePosition="left" inset="2" id="K6A-4z-1aQ">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -562,7 +562,7 @@
                                     <gridCell row="ypY-nL-Mey" column="FRJ-Rb-RRh" id="qmm-s5-QVv"/>
                                     <gridCell row="ypY-nL-Mey" column="V6M-Jv-Agj" id="HXK-XI-g6b">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nCq-b7-xQX">
-                                            <rect key="frame" x="235" y="366" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="366" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Apple and built-in displays already have a brightness slider in Control Center." id="fmZ-HI-Mdc">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -572,7 +572,7 @@
                                     </gridCell>
                                     <gridCell row="d8s-SW-acK" column="FRJ-Rb-RRh" xPlacement="trailing" id="Gjt-20-GPt">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UOL-wV-9me">
-                                            <rect key="frame" x="106" y="340" width="122" height="16"/>
+                                            <rect key="frame" x="90" y="340" width="122" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Additional controls:" id="i5X-M5-Tf5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -582,7 +582,7 @@
                                     </gridCell>
                                     <gridCell row="d8s-SW-acK" column="V6M-Jv-Agj" id="xlB-Gq-kNE">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dbn-VC-UQW">
-                                            <rect key="frame" x="235" y="339" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="339" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show volume slider in menu" bezelStyle="regularSquare" imagePosition="left" inset="2" id="c9D-MB-lma">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -595,7 +595,7 @@
                                     <gridCell row="vSY-dT-S4f" column="FRJ-Rb-RRh" id="Anr-JW-Dhh"/>
                                     <gridCell row="vSY-dT-S4f" column="V6M-Jv-Agj" id="UG9-iN-gCZ">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wot-rC-CRH">
-                                            <rect key="frame" x="235" y="319" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="319" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="For hardware (DDC) controlled displays only." id="POy-35-bh0">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -606,7 +606,7 @@
                                     <gridCell row="xbz-Tf-py0" column="FRJ-Rb-RRh" xPlacement="trailing" id="g8D-7S-8ow"/>
                                     <gridCell row="xbz-Tf-py0" column="V6M-Jv-Agj" xPlacement="leading" id="tLG-sS-Yff">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uYF-Oe-H5a">
-                                            <rect key="frame" x="235" y="292" width="202" height="18"/>
+                                            <rect key="frame" x="218" y="292" width="202" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show contrast slider in menu" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="qO0-dB-yUs">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -619,7 +619,7 @@
                                     <gridCell row="KPA-bi-7h3" column="FRJ-Rb-RRh" id="jqf-Qp-ilZ"/>
                                     <gridCell row="KPA-bi-7h3" column="V6M-Jv-Agj" id="vAI-Aq-T6c">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Od3-K9-Ltb">
-                                            <rect key="frame" x="235" y="272" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="272" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="For hardware (DDC) controlled displays only. Results may vary." id="bIe-6O-xEH">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -628,14 +628,14 @@
                                         </textField>
                                     </gridCell>
                                     <gridCell row="D70-7U-E5E" column="FRJ-Rb-RRh" headOfMergedCell="rGd-Ay-M5k" id="rGd-Ay-M5k">
-                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="QqA-dj-8yX">
-                                            <rect key="frame" x="0.0" y="258" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="QqA-dj-8yX">
+                                            <rect key="frame" x="0.0" y="258" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="D70-7U-E5E" column="V6M-Jv-Agj" headOfMergedCell="rGd-Ay-M5k" id="J3r-Px-7em"/>
                                     <gridCell row="CuW-77-ls4" column="FRJ-Rb-RRh" xPlacement="trailing" id="l3V-an-ba0">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qQD-9e-JNb">
-                                            <rect key="frame" x="119" y="234" width="109" height="16"/>
+                                            <rect key="frame" x="103" y="234" width="109" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Multiple displays:" id="vri-pv-tJ4">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -645,7 +645,7 @@
                                     </gridCell>
                                     <gridCell row="CuW-77-ls4" column="V6M-Jv-Agj" id="4Q7-jo-R9Y">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HcZ-lH-uFI">
-                                            <rect key="frame" x="235" y="233" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="233" width="472" height="18"/>
                                             <buttonCell key="cell" type="radio" title="Show separate controls for each display in menu" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="4t2-Rv-njr">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -658,7 +658,7 @@
                                     <gridCell row="swh-ZB-fkm" column="FRJ-Rb-RRh" id="bRj-zW-Uu8"/>
                                     <gridCell row="swh-ZB-fkm" column="V6M-Jv-Agj" id="mIA-Qn-4jr">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lvN-Ws-Erv">
-                                            <rect key="frame" x="235" y="210" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="210" width="472" height="18"/>
                                             <buttonCell key="cell" type="radio" title="Show sliders only for the display currently showing the menu" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="PvP-TV-OmT">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -671,7 +671,7 @@
                                     <gridCell row="GRh-ZZ-2dj" column="FRJ-Rb-RRh" id="TgX-ay-zjP"/>
                                     <gridCell row="GRh-ZZ-2dj" column="V6M-Jv-Agj" id="vUr-et-hr7">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AOX-rE-fbu">
-                                            <rect key="frame" x="235" y="187" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="187" width="472" height="18"/>
                                             <buttonCell key="cell" type="radio" title="Use combined slider for all displays" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="7rn-Lu-fcl">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -684,7 +684,7 @@
                                     <gridCell row="MaK-MK-gRQ" column="FRJ-Rb-RRh" id="HJf-ZT-Z5d"/>
                                     <gridCell row="MaK-MK-gRQ" column="V6M-Jv-Agj" id="auz-mt-Zu6">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bdc-F8-syo">
-                                            <rect key="frame" x="235" y="167" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="167" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Works best with various syncing and 'control all' keyboard settings enabled." id="XU4-Bn-bwH">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -693,14 +693,14 @@
                                         </textField>
                                     </gridCell>
                                     <gridCell row="7kD-xD-py0" column="FRJ-Rb-RRh" headOfMergedCell="zOL-GT-1cQ" id="zOL-GT-1cQ">
-                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ASF-dP-OR6">
-                                            <rect key="frame" x="0.0" y="153" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ASF-dP-OR6">
+                                            <rect key="frame" x="0.0" y="153" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="7kD-xD-py0" column="V6M-Jv-Agj" headOfMergedCell="zOL-GT-1cQ" id="ZJZ-t6-dPA"/>
                                     <gridCell row="BmS-ju-SrX" column="FRJ-Rb-RRh" xPlacement="trailing" id="HyX-Ez-gvQ">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yvP-ra-lvk">
-                                            <rect key="frame" x="129" y="129" width="99" height="16"/>
+                                            <rect key="frame" x="113" y="129" width="99" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Slider behavior:" id="75n-7M-1mS">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -710,7 +710,7 @@
                                     </gridCell>
                                     <gridCell row="BmS-ju-SrX" column="V6M-Jv-Agj" id="yAf-qw-VHf">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lao-JI-LJH">
-                                            <rect key="frame" x="235" y="128" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="128" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Enable slider snapping" bezelStyle="regularSquare" imagePosition="left" inset="2" id="MlU-hl-d46">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -723,7 +723,7 @@
                                     <gridCell row="dqd-4Y-f2g" column="FRJ-Rb-RRh" id="PTk-Sc-yrY"/>
                                     <gridCell row="dqd-4Y-f2g" column="V6M-Jv-Agj" id="bAh-H3-ggK">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h8b-Qh-3V7">
-                                            <rect key="frame" x="235" y="94" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="94" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="8Gx-Ya-zhp">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Slider knob will snap to 0%, 25%, 50%, 75% and 100% when in proximity making setting these values easier. Disable for finer control.</string>
@@ -735,7 +735,7 @@
                                     <gridCell row="Ojm-8A-t1d" column="FRJ-Rb-RRh" id="QcQ-Yk-pVZ"/>
                                     <gridCell row="Ojm-8A-t1d" column="V6M-Jv-Agj" id="iH6-UD-27v">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1Il-jd-K66">
-                                            <rect key="frame" x="235" y="67" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="67" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show slider tick marks" bezelStyle="regularSquare" imagePosition="left" inset="2" id="7zf-m1-gJO">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -748,7 +748,7 @@
                                     <gridCell row="JCM-Me-DIg" column="FRJ-Rb-RRh" id="4dI-gO-lby"/>
                                     <gridCell row="JCM-Me-DIg" column="V6M-Jv-Agj" id="BrS-uz-AmN">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3UH-lb-LtK">
-                                            <rect key="frame" x="235" y="47" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="47" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Show tick marks at 0%, 25%, 50%, 75% and 100% for accuracy." id="A8P-vn-DEJ">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -759,7 +759,7 @@
                                     <gridCell row="rhT-kW-PmZ" column="FRJ-Rb-RRh" id="efT-lC-BJS"/>
                                     <gridCell row="rhT-kW-PmZ" column="V6M-Jv-Agj" id="N96-bg-tCT">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fkJ-cg-1cE">
-                                            <rect key="frame" x="235" y="20" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="20" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show percentages" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZUu-MR-XwA">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -772,7 +772,7 @@
                                     <gridCell row="fDY-kq-bjz" column="FRJ-Rb-RRh" id="sge-9G-Zny"/>
                                     <gridCell row="fDY-kq-bjz" column="V6M-Jv-Agj" id="ncf-kT-wW1">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Nr-MR-V6g">
-                                            <rect key="frame" x="235" y="0.0" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="0.0" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Show percentage next to slider for more precision." id="qXy-CL-Wf1">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -825,17 +825,17 @@
                 </viewController>
                 <customObject id="oB1-KW-86Y" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="300.5" y="225"/>
+            <point key="canvasLocation" x="298" y="203"/>
         </scene>
         <!--Keyboard Prefs View Controller-->
         <scene sceneID="VuM-5u-zkv">
             <objects>
                 <viewController storyboardIdentifier="KeyboardPrefsVC" id="eJ2-Cv-Vfp" customClass="KeyboardPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="yCl-jO-kpd">
-                        <rect key="frame" x="0.0" y="0.0" width="691" height="817"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="817"/>
                         <subviews>
                             <gridView xPlacement="leading" yPlacement="fill" rowAlignment="none" rowSpacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="bKX-vi-7gY">
-                                <rect key="frame" x="20" y="20" width="651" height="777"/>
+                                <rect key="frame" x="20" y="20" width="690" height="777"/>
                                 <rows>
                                     <gridRow height="20" bottomPadding="-13" id="dwB-Ku-aql"/>
                                     <gridRow topPadding="-13" bottomPadding="-10" id="pf1-cW-4bf"/>
@@ -860,14 +860,14 @@
                                     <gridRow id="isS-lh-NP9"/>
                                 </rows>
                                 <columns>
-                                    <gridColumn width="226" id="ZC2-Ja-sIb"/>
-                                    <gridColumn xPlacement="fill" width="414" leadingPadding="5" id="EiG-65-CTv"/>
+                                    <gridColumn width="210" id="ZC2-Ja-sIb"/>
+                                    <gridColumn xPlacement="fill" width="470" leadingPadding="4" id="EiG-65-CTv"/>
                                 </columns>
                                 <gridCells>
                                     <gridCell row="dwB-Ku-aql" column="ZC2-Ja-sIb" xPlacement="trailing" id="1cK-xF-Xfy">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TXN-Hd-9a2">
-                                            <rect key="frame" x="29" y="757" width="199" height="20"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Brightness and contrast control:" id="LO4-4k-gxY">
+                                            <rect key="frame" x="59" y="757" width="153" height="20"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Brightness and contrast:" id="LO4-4k-gxY">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -876,7 +876,7 @@
                                     </gridCell>
                                     <gridCell row="dwB-Ku-aql" column="EiG-65-CTv" xPlacement="leading" id="YBq-zd-TZe">
                                         <popUpButton key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2NF-gh-JBU">
-                                            <rect key="frame" x="234" y="753" width="260" height="25"/>
+                                            <rect key="frame" x="217" y="753" width="260" height="25"/>
                                             <popUpButtonCell key="cell" type="push" title="Standard keyboard brightness keys" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Oke-bW-cb1" id="h0R-Cc-cJa">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="menu"/>
@@ -899,7 +899,7 @@
                                     <gridCell row="pf1-cW-4bf" column="ZC2-Ja-sIb" id="qIV-EU-GF4"/>
                                     <gridCell row="pf1-cW-4bf" column="EiG-65-CTv" id="xAf-sh-mcN">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="Lm5-La-ZYb">
-                                            <rect key="frame" x="235" y="694" width="418" height="56"/>
+                                            <rect key="frame" x="218" y="694" width="474" height="56"/>
                                             <textFieldCell key="cell" controlSize="small" id="pa0-Hz-ace">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Use the brightness keys of your Apple keyboard to control brightness. You can hold Control to adjust the built-in display, Control+Option to adjust external displays. Hold Shift+Option for fine control. Control+Option+Command adjusts contrast on DDC compatible displays.</string>
@@ -911,7 +911,7 @@
                                     <gridCell row="yxK-w1-5wV" column="ZC2-Ja-sIb" id="JgV-5K-BfL"/>
                                     <gridCell row="yxK-w1-5wV" column="EiG-65-CTv" id="mDy-Cw-udO">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EJp-ld-K4l">
-                                            <rect key="frame" x="235" y="667" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="667" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Do not use alternative brightness keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="vd2-Lk-neX">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -924,7 +924,7 @@
                                     <gridCell row="eGd-bB-47V" column="ZC2-Ja-sIb" id="WGW-vl-p5x"/>
                                     <gridCell row="eGd-bB-47V" column="EiG-65-CTv" id="es9-X3-7zr">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="aFo-6H-zml">
-                                            <rect key="frame" x="235" y="633" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="633" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" title="Alternative keys are the F14/F15 (Scroll Lock and Pause on PC keyboards, brightness keys on some Logitech keyboards)." id="D4H-hU-FLn">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -934,7 +934,7 @@
                                     </gridCell>
                                     <gridCell row="bd8-PJ-Cme" column="ZC2-Ja-sIb" xPlacement="trailing" id="ePJ-iR-Byw">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DC4-V4-qLD">
-                                            <rect key="frame" x="116" y="523" width="112" height="100"/>
+                                            <rect key="frame" x="100" y="523" width="112" height="100"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Record shortcuts:" id="kqJ-jQ-b7U">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -944,20 +944,20 @@
                                     </gridCell>
                                     <gridCell row="bd8-PJ-Cme" column="EiG-65-CTv" xPlacement="leading" yPlacement="top" id="jQx-eE-g8b">
                                         <box key="contentView" boxType="custom" borderType="line" cornerRadius="6" title="#bc-ignore!" translatesAutoresizingMaskIntoConstraints="NO" id="4wn-2u-KRo">
-                                            <rect key="frame" x="237" y="523" width="410" height="100"/>
+                                            <rect key="frame" x="220" y="523" width="440" height="100"/>
                                             <view key="contentView" translatesAutoresizingMaskIntoConstraints="NO" id="vxd-OX-xjN">
-                                                <rect key="frame" x="1" y="1" width="408" height="98"/>
+                                                <rect key="frame" x="1" y="1" width="438" height="98"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <gridView focusRingType="none" fixedFrame="YES" xPlacement="leading" yPlacement="top" rowAlignment="none" translatesAutoresizingMaskIntoConstraints="NO" id="lAP-Wd-eZk">
-                                                        <rect key="frame" x="8" y="10" width="372" height="78"/>
+                                                        <rect key="frame" x="8" y="10" width="392" height="78"/>
                                                         <rows>
                                                             <gridRow height="16" id="UIg-RD-fDW"/>
                                                             <gridRow height="25" id="CrR-ah-GZK"/>
                                                             <gridRow height="25" id="BhM-93-wwI"/>
                                                         </rows>
                                                         <columns>
-                                                            <gridColumn width="80" id="7OZ-s8-7ea"/>
+                                                            <gridColumn width="100" id="7OZ-s8-7ea"/>
                                                             <gridColumn width="140" id="kza-Ox-UgN"/>
                                                             <gridColumn width="140" id="Nu7-d7-fu4"/>
                                                         </columns>
@@ -965,7 +965,7 @@
                                                             <gridCell row="UIg-RD-fDW" column="7OZ-s8-7ea" id="bF2-9n-GUy"/>
                                                             <gridCell row="UIg-RD-fDW" column="kza-Ox-UgN" xPlacement="center" id="1ZW-BN-Xwn">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mFu-sR-Foi">
-                                                                    <rect key="frame" x="122" y="62" width="69" height="16"/>
+                                                                    <rect key="frame" x="142" y="62" width="69" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Brightness" id="IJB-mO-e8I">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -975,7 +975,7 @@
                                                             </gridCell>
                                                             <gridCell row="UIg-RD-fDW" column="Nu7-d7-fu4" xPlacement="center" id="zpo-wB-jPH">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="03L-DE-Tg7">
-                                                                    <rect key="frame" x="253" y="62" width="98" height="16"/>
+                                                                    <rect key="frame" x="273" y="62" width="98" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Contrast (DDC)" id="urd-Rh-aiL">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -983,9 +983,9 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </gridCell>
-                                                            <gridCell row="CrR-ah-GZK" column="7OZ-s8-7ea" xPlacement="trailing" yPlacement="bottom" id="nMx-fx-vb3">
+                                                            <gridCell row="CrR-ah-GZK" column="7OZ-s8-7ea" xPlacement="trailing" yPlacement="center" id="nMx-fx-vb3">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uro-lq-15o">
-                                                                    <rect key="frame" x="22" y="31" width="60" height="16"/>
+                                                                    <rect key="frame" x="42" y="36" width="60" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Increase:" id="eue-as-VOR">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -995,17 +995,17 @@
                                                             </gridCell>
                                                             <gridCell row="CrR-ah-GZK" column="kza-Ox-UgN" xPlacement="center" yPlacement="bottom" id="JRj-Ml-bRq">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="uJd-Dl-olj">
-                                                                    <rect key="frame" x="106" y="31" width="100" height="25"/>
+                                                                    <rect key="frame" x="126" y="31" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
                                                             <gridCell row="CrR-ah-GZK" column="Nu7-d7-fu4" xPlacement="center" yPlacement="bottom" id="eCZ-RS-7gS">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="C1Q-B9-TF4">
-                                                                    <rect key="frame" x="252" y="31" width="100" height="25"/>
+                                                                    <rect key="frame" x="272" y="31" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
-                                                            <gridCell row="BhM-93-wwI" column="7OZ-s8-7ea" xPlacement="trailing" yPlacement="bottom" id="eUm-0L-oYv">
+                                                            <gridCell row="BhM-93-wwI" column="7OZ-s8-7ea" xPlacement="trailing" yPlacement="center" id="eUm-0L-oYv">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jXm-pI-2kM">
-                                                                    <rect key="frame" x="17" y="0.0" width="65" height="16"/>
+                                                                    <rect key="frame" x="37" y="5" width="65" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Decrease:" id="Bzq-Co-fex">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1015,12 +1015,12 @@
                                                             </gridCell>
                                                             <gridCell row="BhM-93-wwI" column="kza-Ox-UgN" xPlacement="center" yPlacement="bottom" id="BhD-n3-0ve">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="ldh-IC-HUY">
-                                                                    <rect key="frame" x="106" y="0.0" width="100" height="25"/>
+                                                                    <rect key="frame" x="126" y="0.0" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
                                                             <gridCell row="BhM-93-wwI" column="Nu7-d7-fu4" xPlacement="center" yPlacement="bottom" id="eKF-ZY-NnV">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="QpM-NB-Drp">
-                                                                    <rect key="frame" x="252" y="0.0" width="100" height="25"/>
+                                                                    <rect key="frame" x="272" y="0.0" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
                                                         </gridCells>
@@ -1028,7 +1028,7 @@
                                                 </subviews>
                                             </view>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="410" id="Fon-gj-YlX"/>
+                                                <constraint firstAttribute="width" constant="440" id="Fon-gj-YlX"/>
                                                 <constraint firstAttribute="height" constant="100" id="z4Q-La-eC5"/>
                                             </constraints>
                                             <color key="borderColor" red="1" green="1" blue="1" alpha="0.14738301570628254" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1037,7 +1037,7 @@
                                     </gridCell>
                                     <gridCell row="I9B-dr-BOu" column="ZC2-Ja-sIb" xPlacement="trailing" id="bAf-Bt-a5c">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tIh-qa-IGb">
-                                            <rect key="frame" x="116" y="493" width="112" height="16"/>
+                                            <rect key="frame" x="100" y="493" width="112" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Screen to control:" id="ltL-gR-K3Z">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1047,7 +1047,7 @@
                                     </gridCell>
                                     <gridCell row="I9B-dr-BOu" column="EiG-65-CTv" id="buZ-hq-416">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5kF-5S-gp2">
-                                            <rect key="frame" x="235" y="492" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="492" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Change for all screens" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JC3-pb-XnR">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1060,7 +1060,7 @@
                                     <gridCell row="7CD-Vz-yse" column="ZC2-Ja-sIb" id="S2B-61-CdS"/>
                                     <gridCell row="7CD-Vz-yse" column="EiG-65-CTv" id="qIc-Sd-rrT">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8PE-jJ-woz">
-                                            <rect key="frame" x="235" y="462" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="462" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Use window focus to determine which display to control" bezelStyle="regularSquare" imagePosition="left" inset="2" id="mMG-Ac-gdB">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1073,7 +1073,7 @@
                                     <gridCell row="UIH-jA-Cfi" column="ZC2-Ja-sIb" id="0mO-T1-WIu"/>
                                     <gridCell row="UIH-jA-Cfi" column="EiG-65-CTv" id="946-Ae-IAi">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="8uZ-DH-JRs">
-                                            <rect key="frame" x="235" y="428" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="428" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="4dX-o1-xAc">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">MonitorControl uses mouse position to determine which display to control. Using window focus instead might not work well with full screen apps.</string>
@@ -1084,7 +1084,7 @@
                                     </gridCell>
                                     <gridCell row="jJT-as-drf" column="ZC2-Ja-sIb" xPlacement="trailing" id="nrK-Hc-7nO">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vWz-eO-w5x">
-                                            <rect key="frame" x="157" y="402" width="71" height="16"/>
+                                            <rect key="frame" x="141" y="402" width="71" height="16"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="OSD scale:" id="bP4-GJ-vhJ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1094,7 +1094,7 @@
                                     </gridCell>
                                     <gridCell row="jJT-as-drf" column="EiG-65-CTv" id="RS1-HU-liD">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="M5g-VZ-qiM">
-                                            <rect key="frame" x="235" y="401" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="401" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Use fine OSD scale" bezelStyle="regularSquare" imagePosition="left" inset="2" id="8Q8-57-xnT">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1107,7 +1107,7 @@
                                     <gridCell row="4Ie-T6-Ifw" column="ZC2-Ja-sIb" id="5r9-mO-Jth"/>
                                     <gridCell row="4Ie-T6-Ifw" column="EiG-65-CTv" id="Ic1-hh-nwR">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="6IT-qa-vjW">
-                                            <rect key="frame" x="235" y="367" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="367" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="f6J-Ui-uMB">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Normally keyboard controls change one OSD chiclet worth of value and Shift+Option allows fine control. This makes fine control default.</string>
@@ -1119,7 +1119,7 @@
                                     <gridCell row="4hU-dS-J9a" column="ZC2-Ja-sIb" id="zvG-Rs-1Wp"/>
                                     <gridCell row="4hU-dS-J9a" column="EiG-65-CTv" id="5T9-2m-uH0">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f8L-OE-kAQ">
-                                            <rect key="frame" x="235" y="340" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="340" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Separate scales for combined hardware &amp; software dimming" bezelStyle="regularSquare" imagePosition="left" inset="2" id="O8o-hI-8eR">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1132,7 +1132,7 @@
                                     <gridCell row="ON8-Vi-iMV" column="ZC2-Ja-sIb" id="ZjD-la-smM"/>
                                     <gridCell row="ON8-Vi-iMV" column="EiG-65-CTv" id="5bt-Sc-Tne">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="qYT-s5-VcV">
-                                            <rect key="frame" x="235" y="306" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="306" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="YHZ-VL-QJ3">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Full OSD scale will be available for hardware brightness control and after reaching 0 brightness, further software dimming will be used.</string>
@@ -1142,14 +1142,14 @@
                                         </textField>
                                     </gridCell>
                                     <gridCell row="9sW-wk-3dM" column="ZC2-Ja-sIb" headOfMergedCell="JSH-kM-pjC" id="JSH-kM-pjC">
-                                        <box key="contentView" autoresizesSubviews="NO" verticalHuggingPriority="750" placeholderIntrinsicWidth="651" placeholderIntrinsicHeight="2" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="TOH-xA-yYJ">
-                                            <rect key="frame" x="0.0" y="292" width="651" height="6"/>
+                                        <box key="contentView" autoresizesSubviews="NO" verticalHuggingPriority="750" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="TOH-xA-yYJ">
+                                            <rect key="frame" x="0.0" y="292" width="690" height="6"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="9sW-wk-3dM" column="EiG-65-CTv" headOfMergedCell="JSH-kM-pjC" id="Nz7-FJ-WeR"/>
                                     <gridCell row="6od-Ek-qTW" column="ZC2-Ja-sIb" xPlacement="trailing" id="9Ea-cn-wzu">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gNu-Sd-s4E">
-                                            <rect key="frame" x="59" y="264" width="169" height="20"/>
+                                            <rect key="frame" x="43" y="264" width="169" height="20"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Volume control (DDC only):" id="qoh-Gn-f11">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1159,7 +1159,7 @@
                                     </gridCell>
                                     <gridCell row="6od-Ek-qTW" column="EiG-65-CTv" xPlacement="leading" id="pCd-dP-Y62">
                                         <popUpButton key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9oZ-JM-bxD">
-                                            <rect key="frame" x="234" y="260" width="293" height="25"/>
+                                            <rect key="frame" x="217" y="260" width="293" height="25"/>
                                             <popUpButtonCell key="cell" type="push" title="Standard keyboard volume and mute keys" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="1sy-Kd-WL5" id="gTf-PQ-2fA">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="menu"/>
@@ -1181,7 +1181,7 @@
                                     </gridCell>
                                     <gridCell row="TxS-hN-bkf" column="ZC2-Ja-sIb" xPlacement="trailing" id="Ifk-Yb-maM">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yTy-HS-HGa">
-                                            <rect key="frame" x="116" y="145" width="112" height="105"/>
+                                            <rect key="frame" x="100" y="145" width="112" height="105"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Record shortcuts:" id="HLE-Vp-kcS">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1191,26 +1191,26 @@
                                     </gridCell>
                                     <gridCell row="TxS-hN-bkf" column="EiG-65-CTv" xPlacement="leading" id="rL9-yD-7Tk">
                                         <box key="contentView" boxType="custom" borderType="line" cornerRadius="6" title="#bc-ignore!" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="9aX-gm-8TS">
-                                            <rect key="frame" x="237" y="145" width="410" height="105"/>
+                                            <rect key="frame" x="220" y="145" width="440" height="105"/>
                                             <view key="contentView" id="iJ6-Kh-tv6">
-                                                <rect key="frame" x="1" y="1" width="408" height="103"/>
+                                                <rect key="frame" x="1" y="1" width="438" height="103"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <gridView focusRingType="none" fixedFrame="YES" xPlacement="leading" yPlacement="top" rowAlignment="none" translatesAutoresizingMaskIntoConstraints="NO" id="YtM-JQ-l82">
-                                                        <rect key="frame" x="7" y="10" width="226" height="87"/>
+                                                        <rect key="frame" x="7" y="10" width="246" height="87"/>
                                                         <rows>
                                                             <gridRow height="25" id="jWq-NI-VHe"/>
                                                             <gridRow height="25" id="xRS-PE-ePP"/>
                                                             <gridRow height="25" id="zvF-Ib-hzw"/>
                                                         </rows>
                                                         <columns>
-                                                            <gridColumn width="80" id="aft-Mx-M3g"/>
+                                                            <gridColumn width="100" id="aft-Mx-M3g"/>
                                                             <gridColumn width="140" id="1Pn-Qh-jNz"/>
                                                         </columns>
                                                         <gridCells>
-                                                            <gridCell row="jWq-NI-VHe" column="aft-Mx-M3g" xPlacement="trailing" yPlacement="bottom" id="SWE-gc-VNH">
+                                                            <gridCell row="jWq-NI-VHe" column="aft-Mx-M3g" xPlacement="trailing" yPlacement="center" id="SWE-gc-VNH">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2JJ-38-ivO">
-                                                                    <rect key="frame" x="22" y="62" width="60" height="16"/>
+                                                                    <rect key="frame" x="42" y="67" width="60" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Increase:" id="mue-fa-8z6">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1220,12 +1220,12 @@
                                                             </gridCell>
                                                             <gridCell row="jWq-NI-VHe" column="1Pn-Qh-jNz" xPlacement="center" yPlacement="bottom" id="oKm-MV-s5R">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="rFx-DX-nFb">
-                                                                    <rect key="frame" x="106" y="62" width="100" height="25"/>
+                                                                    <rect key="frame" x="126" y="62" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
-                                                            <gridCell row="xRS-PE-ePP" column="aft-Mx-M3g" xPlacement="trailing" yPlacement="bottom" id="aBh-ip-mgw">
+                                                            <gridCell row="xRS-PE-ePP" column="aft-Mx-M3g" xPlacement="trailing" yPlacement="center" id="aBh-ip-mgw">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KNl-Fi-0Yu">
-                                                                    <rect key="frame" x="17" y="31" width="65" height="16"/>
+                                                                    <rect key="frame" x="37" y="36" width="65" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Decrease:" id="yQh-Ve-WEE">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1235,12 +1235,12 @@
                                                             </gridCell>
                                                             <gridCell row="xRS-PE-ePP" column="1Pn-Qh-jNz" xPlacement="center" yPlacement="bottom" id="76G-X8-38k">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="cag-2Q-I9P">
-                                                                    <rect key="frame" x="106" y="31" width="100" height="25"/>
+                                                                    <rect key="frame" x="126" y="31" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
                                                             <gridCell row="zvF-Ib-hzw" column="aft-Mx-M3g" xPlacement="trailing" yPlacement="center" id="hkZ-6R-hdq">
                                                                 <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mxu-LD-6Z3">
-                                                                    <rect key="frame" x="43" y="5" width="39" height="16"/>
+                                                                    <rect key="frame" x="63" y="5" width="39" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Mute:" id="EvN-FT-vdZ">
                                                                         <font key="font" usesAppearanceFont="YES"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1250,7 +1250,7 @@
                                                             </gridCell>
                                                             <gridCell row="zvF-Ib-hzw" column="1Pn-Qh-jNz" xPlacement="center" yPlacement="bottom" id="LV4-jR-KKe">
                                                                 <customView key="contentView" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="0l2-EO-6Ip">
-                                                                    <rect key="frame" x="106" y="0.0" width="100" height="25"/>
+                                                                    <rect key="frame" x="126" y="0.0" width="100" height="25"/>
                                                                 </customView>
                                                             </gridCell>
                                                         </gridCells>
@@ -1258,7 +1258,7 @@
                                                 </subviews>
                                             </view>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="410" id="GMj-Ti-YUh"/>
+                                                <constraint firstAttribute="width" constant="440" id="GMj-Ti-YUh"/>
                                                 <constraint firstAttribute="height" constant="105" id="r7A-vj-vfb"/>
                                             </constraints>
                                             <color key="borderColor" red="1" green="1" blue="1" alpha="0.14738301570000001" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1268,7 +1268,7 @@
                                     <gridCell row="LHa-CM-c46" column="ZC2-Ja-sIb" id="4xC-rW-7Hz"/>
                                     <gridCell row="LHa-CM-c46" column="EiG-65-CTv" id="MEm-fE-vTk">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="P7n-7y-LzH">
-                                            <rect key="frame" x="235" y="114" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="114" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Change volume for all screens" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1XT-3S-UuD">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1281,7 +1281,7 @@
                                     <gridCell row="ypS-k5-pR7" column="ZC2-Ja-sIb" id="a23-q4-hTS"/>
                                     <gridCell row="ypS-k5-pR7" column="EiG-65-CTv" id="Lve-9C-7rL">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="Edw-f1-SjL">
-                                            <rect key="frame" x="235" y="94" width="418" height="14"/>
+                                            <rect key="frame" x="218" y="94" width="474" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" title="Works if an audio device is selected with no native volume control." id="uF5-a9-Ngz">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -1292,7 +1292,7 @@
                                     <gridCell row="1kc-MK-daX" column="ZC2-Ja-sIb" id="kwE-ut-eRZ"/>
                                     <gridCell row="1kc-MK-daX" column="EiG-65-CTv" id="mpv-8s-0vx">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jvd-Zg-MJL">
-                                            <rect key="frame" x="235" y="67" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="67" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Use audio device name to determine which display to control" bezelStyle="regularSquare" imagePosition="left" inset="2" id="OAa-B4-8r3">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1305,7 +1305,7 @@
                                     <gridCell row="73k-Ho-qxa" column="ZC2-Ja-sIb" id="auW-Op-Sd7"/>
                                     <gridCell row="73k-Ho-qxa" column="EiG-65-CTv" id="zDs-rB-tfY">
                                         <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="1lU-Y6-hCU">
-                                            <rect key="frame" x="235" y="33" width="418" height="28"/>
+                                            <rect key="frame" x="218" y="33" width="474" height="28"/>
                                             <textFieldCell key="cell" controlSize="small" id="Dha-Tm-cDM">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <string key="title">Without this the app uses mouse position to determine which display to control. You can override audio device name under Displays if needed.</string>
@@ -1317,7 +1317,7 @@
                                     <gridCell row="fUL-yd-WWe" column="ZC2-Ja-sIb" xPlacement="trailing" id="Wh1-8h-lvf"/>
                                     <gridCell row="fUL-yd-WWe" column="EiG-65-CTv" id="E3y-Dw-dnI">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aab-nY-XnS">
-                                            <rect key="frame" x="235" y="6" width="416" height="18"/>
+                                            <rect key="frame" x="218" y="6" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Use fine OSD scale for volume" bezelStyle="regularSquare" imagePosition="left" inset="2" id="J3L-MW-iJL">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1376,7 +1376,7 @@
                 </viewController>
                 <customObject id="aU5-zc-suQ" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="300.5" y="1056.5"/>
+            <point key="canvasLocation" x="298" y="1004.5"/>
         </scene>
         <!--Displays Prefs View Controller-->
         <scene sceneID="lLH-hh-1EK">
@@ -1384,22 +1384,22 @@
                 <customObject id="rw7-Po-Lxm" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <viewController storyboardIdentifier="DisplaysPrefsVC" id="2Ei-9P-f0u" customClass="DisplaysPrefsViewController" customModule="MonitorControl" sceneMemberID="viewController">
                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="aj0-6l-QE2">
-                        <rect key="frame" x="0.0" y="0.0" width="691" height="489"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="489"/>
                         <subviews>
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="490" horizontalPageScroll="10" verticalLineScroll="490" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="O0W-8R-9c8">
-                                <rect key="frame" x="0.0" y="0.0" width="691" height="488"/>
+                                <rect key="frame" x="0.0" y="0.0" width="730" height="488"/>
                                 <clipView key="contentView" drawsBackground="NO" id="yDV-Al-LQT">
-                                    <rect key="frame" x="0.0" y="0.0" width="691" height="488"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="730" height="488"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" tableStyle="inset" selectionHighlightStyle="none" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="490" rowSizeStyle="automatic" viewBased="YES" id="zC9-dS-Tr3">
-                                            <rect key="frame" x="0.0" y="0.0" width="692" height="490"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="730" height="490"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="0.0"/>
                                             <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="660" minWidth="40" maxWidth="660" id="3eK-hg-Tqu">
+                                                <tableColumn width="690" minWidth="40" maxWidth="690" id="3eK-hg-Tqu">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1412,7 +1412,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView wantsLayer="YES" id="hCY-wr-B84" customClass="DisplaysPrefsCellView" customModule="MonitorControl">
-                                                            <rect key="frame" x="18" y="0.0" width="655" height="490"/>
+                                                            <rect key="frame" x="18" y="0.0" width="690" height="490"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <subviews>
                                                                 <imageView wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="Bhw-JQ-dBx">
@@ -1421,7 +1421,7 @@
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageAlignment="top" imageScaling="proportionallyUpOrDown" image="NSTouchBarIconViewTemplate" id="DLq-uQ-NPf"/>
                                                                 </imageView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="jz0-4Z-xVm">
-                                                                    <rect key="frame" x="197" y="419" width="166" height="16"/>
+                                                                    <rect key="frame" x="210" y="419" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="6GJ-6Q-gqz">
                                                                         <font key="font" metaFont="system"/>
@@ -1430,7 +1430,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <button verticalHuggingPriority="750" id="hoM-Lm-YlP">
-                                                                    <rect key="frame" x="365" y="386" width="278" height="18"/>
+                                                                    <rect key="frame" x="385" y="386" width="302" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" title="Use hardware DDC control" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZdU-gV-V05">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1441,7 +1441,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" id="Y93-eX-6aR">
-                                                                    <rect key="frame" x="365" y="418" width="278" height="18"/>
+                                                                    <rect key="frame" x="385" y="418" width="302" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" title="Enable keyboard control for display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="UqR-WE-jHl">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1452,7 +1452,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="aUB-dZ-Kbz">
-                                                                    <rect key="frame" x="78" y="419" width="115" height="16"/>
+                                                                    <rect key="frame" x="78" y="419" width="128" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Identifier:" id="YqZ-LS-YvR">
                                                                         <font key="font" metaFont="system"/>
@@ -1461,11 +1461,11 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <box verticalHuggingPriority="750" boxType="separator" id="VgS-82-jXG">
-                                                                    <rect key="frame" x="80" y="451" width="563" height="5"/>
+                                                                    <rect key="frame" x="80" y="451" width="607" height="5"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 </box>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="vfj-lR-QtG">
-                                                                    <rect key="frame" x="78" y="386" width="115" height="16"/>
+                                                                    <rect key="frame" x="78" y="386" width="128" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Display type:" id="lSJ-6w-KJ2">
                                                                         <font key="font" metaFont="system"/>
@@ -1474,7 +1474,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DmC-gj-anZ">
-                                                                    <rect key="frame" x="197" y="386" width="166" height="16"/>
+                                                                    <rect key="frame" x="210" y="386" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="Pqk-VW-JGY">
                                                                         <font key="font" metaFont="system"/>
@@ -1495,7 +1495,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="2Yf-2b-6A8">
-                                                                    <rect key="frame" x="197" y="355" width="166" height="16"/>
+                                                                    <rect key="frame" x="210" y="355" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="pIy-Lk-kkm">
                                                                         <font key="font" metaFont="system"/>
@@ -1512,7 +1512,7 @@
                                                                     </buttonCell>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" id="ARW-va-sn0">
-                                                                    <rect key="frame" x="365" y="354" width="278" height="18"/>
+                                                                    <rect key="frame" x="385" y="354" width="302" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" title="Disable macOS volume OSD" bezelStyle="regularSquare" imagePosition="left" inset="2" id="bkM-Px-U3b">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1522,19 +1522,8 @@
                                                                         <action selector="disableVolumeOSDButton:" target="hCY-wr-B84" id="Sxh-1k-MCj"/>
                                                                     </connections>
                                                                 </button>
-                                                                <button verticalHuggingPriority="750" id="uug-2q-b5U">
-                                                                    <rect key="frame" x="529" y="456" width="120" height="31"/>
-                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <buttonCell key="cell" type="push" title="Reset settings" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="BYS-7Y-bRz">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="smallSystem"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetSettings:" target="hCY-wr-B84" id="aV0-s1-EYI"/>
-                                                                    </connections>
-                                                                </button>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1PG-t6-jkR">
-                                                                    <rect key="frame" x="78" y="355" width="115" height="16"/>
+                                                                    <rect key="frame" x="78" y="355" width="128" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Control method:" id="PaK-1f-DsW">
                                                                         <font key="font" metaFont="system"/>
@@ -1543,13 +1532,13 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="6" translatesAutoresizingMaskIntoConstraints="NO" id="ihQ-SK-x7Y">
-                                                                    <rect key="frame" x="80" y="20" width="563" height="315"/>
+                                                                    <rect key="frame" x="80" y="20" width="607" height="315"/>
                                                                     <view key="contentView" autoresizesSubviews="NO" id="sNT-7f-pNP">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="563" height="315"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="607" height="315"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="102" translatesAutoresizingMaskIntoConstraints="NO" id="2ys-EO-duG">
-                                                                                <rect key="frame" x="419" y="155" width="102" height="19"/>
+                                                                                <rect key="frame" x="485" y="155" width="102" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="LZ8-Tj-mCs">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1561,7 +1550,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="102" id="zz1-Dn-410">
-                                                                                <rect key="frame" x="242" y="217" width="204" height="19"/>
+                                                                                <rect key="frame" x="272" y="217" width="204" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" bezelStyle="round" id="BeE-eB-GgA">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1573,7 +1562,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="1" preferredMaxLayoutWidth="102" id="567-le-fLg">
-                                                                                <rect key="frame" x="174" y="61" width="56" height="19"/>
+                                                                                <rect key="frame" x="194" y="61" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="BCC-To-Wrc">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1586,7 +1575,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="2" preferredMaxLayoutWidth="102" id="pNh-sJ-xaI">
-                                                                                <rect key="frame" x="174" y="36" width="56" height="19"/>
+                                                                                <rect key="frame" x="194" y="36" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="D0z-Bt-f3I">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1598,7 +1587,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="2" preferredMaxLayoutWidth="102" id="Yd0-Nh-RRg">
-                                                                                <rect key="frame" x="239" y="36" width="56" height="19"/>
+                                                                                <rect key="frame" x="264" y="36" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="gYr-9m-bch">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1610,7 +1599,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="1" preferredMaxLayoutWidth="102" id="uJS-s3-Zpi">
-                                                                                <rect key="frame" x="239" y="62" width="56" height="19"/>
+                                                                                <rect key="frame" x="264" y="62" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="c6R-81-tMV">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1623,7 +1612,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <popUpButton verticalHuggingPriority="750" id="7FH-uw-jcn">
-                                                                                <rect key="frame" x="238" y="151" width="108" height="26"/>
+                                                                                <rect key="frame" x="268" y="151" width="108" height="26"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="center" controlSize="small" lineBreakMode="truncatingTail" enabled="NO" state="on" borderStyle="border" tag="-2" inset="2" selectedItem="FoA-yh-Yx3" id="M5p-a2-UEs">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1643,7 +1632,7 @@
                                                                                 </connections>
                                                                             </popUpButton>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="yU6-4R-6Ji">
-                                                                                <rect key="frame" x="-2" y="290" width="567" height="14"/>
+                                                                                <rect key="frame" x="-2" y="290" width="611" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="⚠️ Warning! Changing some of these settings may cause system freezes or unexpected behavior!" id="Cz1-Mh-llk">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1652,7 +1641,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <button verticalHuggingPriority="750" id="42E-Sk-KYk">
-                                                                                <rect key="frame" x="241" y="192" width="308" height="16"/>
+                                                                                <rect key="frame" x="271" y="192" width="308" height="16"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" title="Enable Mute DDC command" bezelStyle="regularSquare" imagePosition="left" controlSize="small" enabled="NO" inset="2" id="bZq-0d-lJa">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1663,7 +1652,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="krX-bC-QxX">
-                                                                                <rect key="frame" x="10" y="158" width="222" height="14"/>
+                                                                                <rect key="frame" x="-2" y="158" width="254" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="DDC read polling mode:" id="vwm-hY-on5">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1672,7 +1661,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="NEl-Fq-xdB">
-                                                                                <rect key="frame" x="5" y="65" width="84" height="14"/>
+                                                                                <rect key="frame" x="5" y="65" width="96" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Brightness:" id="Bhb-6l-uPQ">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1681,7 +1670,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="GCA-hE-qfi">
-                                                                                <rect key="frame" x="96" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="106" y="95" width="82" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="Available" id="yBJ-5d-I7e">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1690,7 +1679,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="z89-mw-TuF">
-                                                                                <rect key="frame" x="169" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="184" y="95" width="76" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="DDC min" id="1zE-fg-xEm">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1699,7 +1688,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="MDr-kO-InC">
-                                                                                <rect key="frame" x="234" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="254" y="95" width="75" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="DDC max" id="psF-vX-AFB">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1708,7 +1697,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="FOA-Ev-gQ2">
-                                                                                <rect key="frame" x="305" y="95" width="118" height="14"/>
+                                                                                <rect key="frame" x="328" y="95" width="131" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="Scale mapping curve" id="Eui-5S-JR6">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1717,7 +1706,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="xP6-gl-gpD">
-                                                                                <rect key="frame" x="5" y="39" width="84" height="14"/>
+                                                                                <rect key="frame" x="5" y="39" width="96" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Volume:" id="FER-Ri-4UO">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1726,7 +1715,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="9qU-4J-Zng">
-                                                                                <rect key="frame" x="5" y="14" width="84" height="14"/>
+                                                                                <rect key="frame" x="5" y="14" width="96" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Contrast:" id="MMk-S2-yJN">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1735,7 +1724,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <slider verticalHuggingPriority="750" tag="2" id="2ae-8s-A50">
-                                                                                <rect key="frame" x="309" y="30" width="110" height="28"/>
+                                                                                <rect key="frame" x="339" y="30" width="110" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="1" maxValue="9" doubleValue="5" tickMarkPosition="above" numberOfTickMarks="9" allowsTickMarkValuesOnly="YES" sliderType="linear" id="vh6-Rx-yYl"/>
                                                                                 <connections>
@@ -1743,7 +1732,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <slider verticalHuggingPriority="750" tag="3" id="W4G-N2-vlQ">
-                                                                                <rect key="frame" x="309" y="5" width="110" height="28"/>
+                                                                                <rect key="frame" x="339" y="5" width="110" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="1" maxValue="9" doubleValue="5" tickMarkPosition="above" numberOfTickMarks="9" allowsTickMarkValuesOnly="YES" sliderType="linear" id="nC8-ua-GRh"/>
                                                                                 <connections>
@@ -1751,7 +1740,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <button verticalHuggingPriority="750" tag="1" id="Su5-Vg-rpV">
-                                                                                <rect key="frame" x="120" y="62" width="18" height="18"/>
+                                                                                <rect key="frame" x="138" y="62" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="xMw-Wd-xQ6">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1762,7 +1751,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <button verticalHuggingPriority="750" tag="3" id="Kb0-Ax-1cf">
-                                                                                <rect key="frame" x="120" y="12" width="18" height="18"/>
+                                                                                <rect key="frame" x="138" y="12" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="v7C-Wy-WDQ">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1773,7 +1762,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="lDb-3J-COl">
-                                                                                <rect key="frame" x="411" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="446" y="95" width="66" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="Invert" id="G5A-y3-eZz">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1782,7 +1771,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <button verticalHuggingPriority="750" tag="1" id="RkH-7d-KvR">
-                                                                                <rect key="frame" x="435" y="62" width="18" height="18"/>
+                                                                                <rect key="frame" x="470" y="62" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9oe-PD-cV0">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1794,7 +1783,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <button verticalHuggingPriority="750" tag="2" id="Mij-q3-1ft">
-                                                                                <rect key="frame" x="435" y="37" width="18" height="18"/>
+                                                                                <rect key="frame" x="470" y="37" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ydK-qV-DP4">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1805,7 +1794,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <button verticalHuggingPriority="750" tag="3" id="4rq-kh-t8s">
-                                                                                <rect key="frame" x="435" y="12" width="18" height="18"/>
+                                                                                <rect key="frame" x="470" y="12" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Rfi-FX-Gof">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1816,7 +1805,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="3" preferredMaxLayoutWidth="102" id="13Q-Fh-Tqu">
-                                                                                <rect key="frame" x="174" y="12" width="56" height="19"/>
+                                                                                <rect key="frame" x="194" y="12" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="WVX-vU-OzE">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1828,7 +1817,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="3" preferredMaxLayoutWidth="102" id="3bU-6D-8YU">
-                                                                                <rect key="frame" x="239" y="11" width="56" height="19"/>
+                                                                                <rect key="frame" x="264" y="11" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="I6z-YY-E7o">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1840,7 +1829,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="2" preferredMaxLayoutWidth="102" id="1GJ-OV-hV7">
-                                                                                <rect key="frame" x="478" y="36" width="69" height="19"/>
+                                                                                <rect key="frame" x="523" y="36" width="69" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="pSA-6B-yWO">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1852,7 +1841,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="1" preferredMaxLayoutWidth="102" id="xDF-IA-bBh">
-                                                                                <rect key="frame" x="478" y="62" width="69" height="19"/>
+                                                                                <rect key="frame" x="523" y="62" width="69" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="8hh-S6-be0">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1865,7 +1854,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="evc-ST-hPR">
-                                                                                <rect key="frame" x="477" y="95" width="72" height="14"/>
+                                                                                <rect key="frame" x="504" y="95" width="106" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="VCP list" id="D9t-vT-gNJ">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1874,7 +1863,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="3" preferredMaxLayoutWidth="102" id="l9M-iL-Kth">
-                                                                                <rect key="frame" x="478" y="11" width="69" height="19"/>
+                                                                                <rect key="frame" x="523" y="11" width="69" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="ANQ-Hz-2pj">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1886,31 +1875,31 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <box horizontalHuggingPriority="750" boxType="separator" id="kUc-7L-ocn">
-                                                                                <rect key="frame" x="93" y="6" width="5" height="102"/>
+                                                                                <rect key="frame" x="105" y="6" width="5" height="102"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="cs7-ty-i3Y">
-                                                                                <rect key="frame" x="0.0" y="85" width="563" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="85" width="607" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="H0Q-BF-CRm">
-                                                                                <rect key="frame" x="0.0" y="182" width="563" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="182" width="607" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="Iee-Pu-9P6">
-                                                                                <rect key="frame" x="0.0" y="119" width="563" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="119" width="607" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="8E8-uG-1Fi">
-                                                                                <rect key="frame" x="0.0" y="243" width="563" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="243" width="607" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box horizontalHuggingPriority="750" boxType="separator" id="Lwb-97-PiW">
-                                                                                <rect key="frame" x="463" y="6" width="5" height="102"/>
+                                                                                <rect key="frame" x="504" y="6" width="5" height="102"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="WZ8-R0-wSk">
-                                                                                <rect key="frame" x="10" y="218" width="222" height="14"/>
+                                                                                <rect key="frame" x="-2" y="218" width="254" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Override audio device name:" id="H9X-it-sXs">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1919,7 +1908,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="z0P-UW-eeF">
-                                                                                <rect key="frame" x="10" y="259" width="222" height="14"/>
+                                                                                <rect key="frame" x="-2" y="259" width="254" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Combined dimming switchover point:" id="zv8-pZ-OPy">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1928,7 +1917,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <button verticalHuggingPriority="750" id="PJz-Jc-hZ4">
-                                                                                <rect key="frame" x="241" y="132" width="308" height="16"/>
+                                                                                <rect key="frame" x="271" y="132" width="308" height="16"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" title="Longer delay during DDC read operations" bezelStyle="regularSquare" imagePosition="left" controlSize="small" enabled="NO" inset="2" id="pF5-Sw-7BR">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1939,11 +1928,11 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <box horizontalHuggingPriority="750" boxType="separator" id="FKO-m4-Pxh">
-                                                                                <rect key="frame" x="159" y="6" width="5" height="102"/>
+                                                                                <rect key="frame" x="182" y="6" width="5" height="102"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <button verticalHuggingPriority="750" tag="2" id="3fe-KY-R1n">
-                                                                                <rect key="frame" x="120" y="37" width="18" height="18"/>
+                                                                                <rect key="frame" x="138" y="37" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="eaq-Ri-0hP">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1954,7 +1943,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <slider verticalHuggingPriority="750" tag="1" id="9H1-0z-xsx">
-                                                                                <rect key="frame" x="309" y="56" width="110" height="28"/>
+                                                                                <rect key="frame" x="339" y="56" width="110" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="1" maxValue="9" doubleValue="5" tickMarkPosition="above" numberOfTickMarks="9" allowsTickMarkValuesOnly="YES" sliderType="linear" id="HPs-Bd-Ymf"/>
                                                                                 <accessibility description="Brightness"/>
@@ -1963,7 +1952,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <slider verticalHuggingPriority="750" tag="1" id="OG9-iA-jK1">
-                                                                                <rect key="frame" x="240" y="249" width="208" height="28"/>
+                                                                                <rect key="frame" x="270" y="249" width="208" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="-8" maxValue="7" tickMarkPosition="above" numberOfTickMarks="16" allowsTickMarkValuesOnly="YES" sliderType="linear" id="c6i-bm-1LB"/>
                                                                                 <accessibility description="Brightness"/>
@@ -1972,7 +1961,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <button verticalHuggingPriority="750" id="veV-At-I0T">
-                                                                                <rect key="frame" x="448" y="209" width="105" height="31"/>
+                                                                                <rect key="frame" x="479" y="209" width="114" height="31"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="push" title="Get current" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hkC-vq-IcD">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1983,7 +1972,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YRZ-Kw-qqG">
-                                                                                <rect key="frame" x="351" y="158" width="63" height="14"/>
+                                                                                <rect key="frame" x="388" y="158" width="87" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="count:" id="Orv-yj-Nad">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1992,7 +1981,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1ct-qM-zrz">
-                                                                                <rect key="frame" x="452" y="259" width="97" height="14"/>
+                                                                                <rect key="frame" x="483" y="259" width="106" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="(Gamma-&gt;DDC)" id="Bid-UL-blc">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -2003,7 +1992,7 @@
                                                                         </subviews>
                                                                     </view>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="563" id="VEg-M2-Y3v"/>
+                                                                        <constraint firstAttribute="width" constant="607" id="VEg-M2-Y3v"/>
                                                                         <constraint firstAttribute="height" constant="315" id="qRf-Ll-HYh"/>
                                                                     </constraints>
                                                                     <shadow key="shadow" blurRadius="2">
@@ -2012,6 +2001,17 @@
                                                                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 </box>
+                                                                <button verticalHuggingPriority="750" id="uug-2q-b5U">
+                                                                    <rect key="frame" x="541" y="455" width="152" height="31"/>
+                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                    <buttonCell key="cell" type="push" title="Reset settings" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="BYS-7Y-bRz">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="resetSettings:" target="hCY-wr-B84" id="aV0-s1-EYI"/>
+                                                                    </connections>
+                                                                </button>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstItem="ihQ-SK-x7Y" firstAttribute="top" secondItem="ARW-va-sn0" secondAttribute="bottom" constant="20" id="lYu-y9-iVv"/>
@@ -2080,7 +2080,7 @@
                             <constraint firstItem="O0W-8R-9c8" firstAttribute="leading" secondItem="aj0-6l-QE2" secondAttribute="leading" id="MNc-WK-uDZ"/>
                             <constraint firstAttribute="height" constant="489" id="O7b-uo-bc2"/>
                             <constraint firstItem="O0W-8R-9c8" firstAttribute="top" secondItem="aj0-6l-QE2" secondAttribute="top" constant="1" id="Rg2-d3-Mrg"/>
-                            <constraint firstAttribute="width" constant="691" id="sZT-qe-hQV"/>
+                            <constraint firstAttribute="width" constant="730" id="sZT-qe-hQV"/>
                             <constraint firstAttribute="trailing" secondItem="O0W-8R-9c8" secondAttribute="trailing" id="xUm-oc-lj8"/>
                         </constraints>
                     </view>
@@ -2091,17 +2091,17 @@
                     </connections>
                 </viewController>
             </objects>
-            <point key="canvasLocation" x="300.5" y="1795.5"/>
+            <point key="canvasLocation" x="298" y="1743.5"/>
         </scene>
         <!--About Prefs View Controller-->
         <scene sceneID="Ot2-lL-eIg">
             <objects>
                 <viewController storyboardIdentifier="AboutPrefsVC" id="7uI-eE-yxm" customClass="AboutPrefsViewController" customModule="MonitorControl" sceneMemberID="viewController">
                     <view key="view" wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kXT-i4-NNT">
-                        <rect key="frame" x="0.0" y="0.0" width="691" height="307"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="307"/>
                         <subviews>
                             <textField identifier="versionLabel" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="tMg-qE-zTW">
-                                <rect key="frame" x="272" y="211" width="333" height="16"/>
+                                <rect key="frame" x="272" y="211" width="440" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="#bc-ignore!" id="mBs-6m-13Q">
                                     <font key="font" metaFont="system"/>
@@ -2110,7 +2110,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Dqc-RQ-Lbc">
-                                <rect key="frame" x="272" y="76" width="333" height="16"/>
+                                <rect key="frame" x="272" y="76" width="440" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="#bc-ignore!" id="e0q-fb-k7R">
                                     <font key="font" metaFont="system"/>
@@ -2128,15 +2128,15 @@
                                 </textFieldCell>
                             </textField>
                             <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9Mt-M9-Xqc">
-                                <rect key="frame" x="274" y="240" width="329" height="4"/>
+                                <rect key="frame" x="274" y="240" width="370" height="4"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </box>
                             <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="JqO-vB-ykl">
-                                <rect key="frame" x="275" y="54" width="329" height="4"/>
+                                <rect key="frame" x="275" y="54" width="370" height="4"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </box>
                             <textField identifier="copyrightLabel" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="mjR-ls-0mP">
-                                <rect key="frame" x="272" y="143" width="147" height="48"/>
+                                <rect key="frame" x="272" y="143" width="440" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" id="TKd-J8-Iyk">
                                     <font key="font" metaFont="systemMedium" size="13"/>
@@ -2148,23 +2148,12 @@
                                 </textFieldCell>
                             </textField>
                             <imageView identifier="appIcon" wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="qQ1-AF-le8">
-                                <rect key="frame" x="65" y="114" width="185" height="185"/>
+                                <rect key="frame" x="70" y="114" width="185" height="185"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="axesIndependently" image="NSApplicationIcon" id="2rQ-WJ-rCY"/>
                             </imageView>
-                            <button verticalHuggingPriority="750" id="D9i-nX-VSm">
-                                <rect key="frame" x="444" y="13" width="167" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="push" title="Website" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Cln-uW-2dd">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="openWebPage:" target="7uI-eE-yxm" id="iqt-JK-xaO"/>
-                                </connections>
-                            </button>
                             <button verticalHuggingPriority="750" id="vS5-oh-3k6">
-                                <rect key="frame" x="268" y="13" width="166" height="32"/>
+                                <rect key="frame" x="268" y="13" width="187" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="push" title="Donate" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ZKk-ve-rS4">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -2175,7 +2164,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" id="rqH-BW-IT6">
-                                <rect key="frame" x="274" y="107" width="329" height="20"/>
+                                <rect key="frame" x="274" y="107" width="436" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="bevel" title="Special thanks to our contributors!" bezelStyle="rounded" alignment="left" imageScaling="proportionallyDown" inset="2" id="95V-M4-2l5">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -2186,10 +2175,21 @@
                                     <action selector="openContributorsPage:" target="7uI-eE-yxm" id="YbP-4y-EPf"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" id="D9i-nX-VSm">
+                                <rect key="frame" x="465" y="13" width="187" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Website" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Cln-uW-2dd">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="openWebPage:" target="7uI-eE-yxm" id="iqt-JK-xaO"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="height" constant="307" id="hXB-ku-c1r"/>
-                            <constraint firstAttribute="width" constant="691" id="kEY-xf-vB5"/>
+                            <constraint firstAttribute="width" constant="730" id="kEY-xf-vB5"/>
                         </constraints>
                     </view>
                     <connections>
@@ -2200,7 +2200,7 @@
                 </viewController>
                 <customObject id="5Vf-Rd-nyE" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="295" y="2275"/>
+            <point key="canvasLocation" x="298" y="2228"/>
         </scene>
     </scenes>
     <resources>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -1393,7 +1393,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" tableStyle="inset" selectionHighlightStyle="none" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="490" rowSizeStyle="automatic" viewBased="YES" id="zC9-dS-Tr3">
-                                            <rect key="frame" x="0.0" y="0.0" width="730" height="490"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="730" height="488"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="0.0"/>
                                             <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -1033,6 +1033,7 @@
                                             </constraints>
                                             <color key="borderColor" red="1" green="1" blue="1" alpha="0.14738301570628254" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="fillColor" red="0.59607843137254901" green="0.59607843137254901" blue="0.61568627450980395" alpha="0.15133397108843538" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="titleFont" metaFont="smallSystem"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="I9B-dr-BOu" column="ZC2-Ja-sIb" xPlacement="trailing" id="bAf-Bt-a5c">
@@ -1263,6 +1264,7 @@
                                             </constraints>
                                             <color key="borderColor" red="1" green="1" blue="1" alpha="0.14738301570000001" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="fillColor" red="0.59607843140000005" green="0.59607843140000005" blue="0.61568627450000002" alpha="0.15133397109999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="titleFont" metaFont="smallSystem"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="LHa-CM-c46" column="ZC2-Ja-sIb" id="4xC-rW-7Hz"/>
@@ -1393,13 +1395,13 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" tableStyle="inset" selectionHighlightStyle="none" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="490" rowSizeStyle="automatic" viewBased="YES" id="zC9-dS-Tr3">
-                                            <rect key="frame" x="0.0" y="0.0" width="691" height="490"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="692" height="490"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="0.0"/>
                                             <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="645" minWidth="40" maxWidth="660" id="3eK-hg-Tqu">
+                                                <tableColumn width="660" minWidth="40" maxWidth="660" id="3eK-hg-Tqu">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1412,16 +1414,16 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView wantsLayer="YES" id="hCY-wr-B84" customClass="DisplaysPrefsCellView" customModule="MonitorControl">
-                                                            <rect key="frame" x="18" y="0.0" width="640" height="490"/>
+                                                            <rect key="frame" x="18" y="0.0" width="655" height="490"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <subviews>
                                                                 <imageView wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="Bhw-JQ-dBx">
-                                                                    <rect key="frame" x="11" y="420.5" width="64" height="69"/>
+                                                                    <rect key="frame" x="3" y="420.5" width="64" height="69"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageAlignment="top" imageScaling="proportionallyUpOrDown" image="NSTouchBarIconViewTemplate" id="DLq-uQ-NPf"/>
                                                                 </imageView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="jz0-4Z-xVm">
-                                                                    <rect key="frame" x="205" y="419" width="156" height="16"/>
+                                                                    <rect key="frame" x="197" y="419" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="6GJ-6Q-gqz">
                                                                         <font key="font" metaFont="system"/>
@@ -1430,7 +1432,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <button verticalHuggingPriority="750" id="hoM-Lm-YlP">
-                                                                    <rect key="frame" x="365" y="386" width="272" height="18"/>
+                                                                    <rect key="frame" x="365" y="386" width="278" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" title="Use hardware DDC control" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZdU-gV-V05">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1441,7 +1443,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" id="Y93-eX-6aR">
-                                                                    <rect key="frame" x="365" y="418" width="272" height="18"/>
+                                                                    <rect key="frame" x="365" y="418" width="278" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" title="Enable keyboard control for display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="UqR-WE-jHl">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1452,29 +1454,29 @@
                                                                     </connections>
                                                                 </button>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="aUB-dZ-Kbz">
-                                                                    <rect key="frame" x="86" y="419" width="115" height="16"/>
+                                                                    <rect key="frame" x="78" y="419" width="115" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Identifier:" id="YqZ-LS-YvR">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Identifier:" id="YqZ-LS-YvR">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <box verticalHuggingPriority="750" boxType="separator" id="VgS-82-jXG">
-                                                                    <rect key="frame" x="88" y="451" width="549" height="5"/>
+                                                                    <rect key="frame" x="80" y="451" width="563" height="5"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 </box>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="vfj-lR-QtG">
-                                                                    <rect key="frame" x="86" y="386" width="115" height="16"/>
+                                                                    <rect key="frame" x="78" y="386" width="115" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Display type:" id="lSJ-6w-KJ2">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Display type:" id="lSJ-6w-KJ2">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="DmC-gj-anZ">
-                                                                    <rect key="frame" x="205" y="386" width="156" height="16"/>
+                                                                    <rect key="frame" x="197" y="386" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="Pqk-VW-JGY">
                                                                         <font key="font" metaFont="system"/>
@@ -1483,7 +1485,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" id="mIA-Wh-7aB">
-                                                                    <rect key="frame" x="86" y="462" width="285" height="21"/>
+                                                                    <rect key="frame" x="78" y="462" width="285" height="21"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="#bc-ignore!" id="ibQ-4u-ClE">
                                                                         <font key="font" textStyle="title2" name=".SFNS-Regular"/>
@@ -1495,7 +1497,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" id="2Yf-2b-6A8">
-                                                                    <rect key="frame" x="205" y="355" width="156" height="16"/>
+                                                                    <rect key="frame" x="197" y="355" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="pIy-Lk-kkm">
                                                                         <font key="font" metaFont="system"/>
@@ -1504,7 +1506,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <button verticalHuggingPriority="750" id="dw1-C8-5US">
-                                                                    <rect key="frame" x="18" y="490" width="640" height="32"/>
+                                                                    <rect key="frame" x="10" y="490" width="640" height="32"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="push" title="Reset Name" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="f9g-8s-gdd">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1512,7 +1514,7 @@
                                                                     </buttonCell>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" id="ARW-va-sn0">
-                                                                    <rect key="frame" x="365" y="354" width="272" height="18"/>
+                                                                    <rect key="frame" x="365" y="354" width="278" height="18"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="check" title="Disable macOS volume OSD" bezelStyle="regularSquare" imagePosition="left" inset="2" id="bkM-Px-U3b">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1523,7 +1525,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" id="uug-2q-b5U">
-                                                                    <rect key="frame" x="523" y="456" width="120" height="31"/>
+                                                                    <rect key="frame" x="529" y="456" width="120" height="31"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <buttonCell key="cell" type="push" title="Reset settings" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="BYS-7Y-bRz">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1534,22 +1536,22 @@
                                                                     </connections>
                                                                 </button>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1PG-t6-jkR">
-                                                                    <rect key="frame" x="86" y="355" width="115" height="16"/>
+                                                                    <rect key="frame" x="78" y="355" width="115" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Control method:" id="PaK-1f-DsW">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Control method:" id="PaK-1f-DsW">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" cornerRadius="6" translatesAutoresizingMaskIntoConstraints="NO" id="ihQ-SK-x7Y">
-                                                                    <rect key="frame" x="88" y="20" width="549" height="315"/>
+                                                                    <rect key="frame" x="80" y="20" width="563" height="315"/>
                                                                     <view key="contentView" autoresizesSubviews="NO" id="sNT-7f-pNP">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="549" height="315"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="563" height="315"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="102" translatesAutoresizingMaskIntoConstraints="NO" id="2ys-EO-duG">
-                                                                                <rect key="frame" x="405" y="155" width="102" height="19"/>
+                                                                                <rect key="frame" x="419" y="155" width="102" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="LZ8-Tj-mCs">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1561,7 +1563,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="102" id="zz1-Dn-410">
-                                                                                <rect key="frame" x="228" y="217" width="204" height="19"/>
+                                                                                <rect key="frame" x="242" y="217" width="204" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" bezelStyle="round" id="BeE-eB-GgA">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1573,7 +1575,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="1" preferredMaxLayoutWidth="102" id="567-le-fLg">
-                                                                                <rect key="frame" x="172" y="61" width="56" height="19"/>
+                                                                                <rect key="frame" x="174" y="61" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="BCC-To-Wrc">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1586,7 +1588,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="2" preferredMaxLayoutWidth="102" id="pNh-sJ-xaI">
-                                                                                <rect key="frame" x="172" y="36" width="56" height="19"/>
+                                                                                <rect key="frame" x="174" y="36" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="D0z-Bt-f3I">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1598,7 +1600,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="2" preferredMaxLayoutWidth="102" id="Yd0-Nh-RRg">
-                                                                                <rect key="frame" x="237" y="36" width="56" height="19"/>
+                                                                                <rect key="frame" x="239" y="36" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="gYr-9m-bch">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1610,7 +1612,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="1" preferredMaxLayoutWidth="102" id="uJS-s3-Zpi">
-                                                                                <rect key="frame" x="237" y="62" width="56" height="19"/>
+                                                                                <rect key="frame" x="239" y="62" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="c6R-81-tMV">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1623,7 +1625,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <popUpButton verticalHuggingPriority="750" id="7FH-uw-jcn">
-                                                                                <rect key="frame" x="224" y="151" width="108" height="26"/>
+                                                                                <rect key="frame" x="238" y="151" width="108" height="26"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <popUpButtonCell key="cell" type="push" title="None" bezelStyle="rounded" alignment="center" controlSize="small" lineBreakMode="truncatingTail" enabled="NO" state="on" borderStyle="border" tag="-2" inset="2" selectedItem="FoA-yh-Yx3" id="M5p-a2-UEs">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1643,7 +1645,7 @@
                                                                                 </connections>
                                                                             </popUpButton>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="yU6-4R-6Ji">
-                                                                                <rect key="frame" x="-2" y="290" width="553" height="14"/>
+                                                                                <rect key="frame" x="-2" y="290" width="567" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="⚠️ Warning! Changing some of these settings may cause system freezes or unexpected behavior!" id="Cz1-Mh-llk">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1652,7 +1654,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <button verticalHuggingPriority="750" id="42E-Sk-KYk">
-                                                                                <rect key="frame" x="227" y="192" width="302" height="16"/>
+                                                                                <rect key="frame" x="241" y="192" width="308" height="16"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" title="Enable Mute DDC command" bezelStyle="regularSquare" imagePosition="left" controlSize="small" enabled="NO" inset="2" id="bZq-0d-lJa">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1663,7 +1665,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="krX-bC-QxX">
-                                                                                <rect key="frame" x="10" y="158" width="206" height="14"/>
+                                                                                <rect key="frame" x="10" y="158" width="222" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="DDC read polling mode:" id="vwm-hY-on5">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1672,9 +1674,9 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="NEl-Fq-xdB">
-                                                                                <rect key="frame" x="17" y="65" width="81" height="14"/>
+                                                                                <rect key="frame" x="10" y="65" width="79" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="left" title="Brightness:" id="Bhb-6l-uPQ">
+                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Brightness:" id="Bhb-6l-uPQ">
                                                                                     <font key="font" metaFont="smallSystem"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1690,7 +1692,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="z89-mw-TuF">
-                                                                                <rect key="frame" x="167" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="169" y="95" width="66" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="DDC min" id="1zE-fg-xEm">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1699,7 +1701,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="MDr-kO-InC">
-                                                                                <rect key="frame" x="232" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="234" y="95" width="66" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="DDC max" id="psF-vX-AFB">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1708,7 +1710,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="FOA-Ev-gQ2">
-                                                                                <rect key="frame" x="303" y="95" width="118" height="14"/>
+                                                                                <rect key="frame" x="305" y="95" width="118" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="Scale mapping curve" id="Eui-5S-JR6">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1717,25 +1719,25 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="xP6-gl-gpD">
-                                                                                <rect key="frame" x="17" y="39" width="81" height="14"/>
+                                                                                <rect key="frame" x="10" y="39" width="79" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="left" title="Volume:" id="FER-Ri-4UO">
+                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Volume:" id="FER-Ri-4UO">
                                                                                     <font key="font" metaFont="smallSystem"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="9qU-4J-Zng">
-                                                                                <rect key="frame" x="17" y="14" width="81" height="14"/>
+                                                                                <rect key="frame" x="10" y="14" width="79" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="left" title="Contrast:" id="MMk-S2-yJN">
+                                                                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Contrast:" id="MMk-S2-yJN">
                                                                                     <font key="font" metaFont="smallSystem"/>
                                                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <slider verticalHuggingPriority="750" tag="2" id="2ae-8s-A50">
-                                                                                <rect key="frame" x="307" y="30" width="110" height="28"/>
+                                                                                <rect key="frame" x="309" y="30" width="110" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="1" maxValue="9" doubleValue="5" tickMarkPosition="above" numberOfTickMarks="9" allowsTickMarkValuesOnly="YES" sliderType="linear" id="vh6-Rx-yYl"/>
                                                                                 <connections>
@@ -1743,7 +1745,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <slider verticalHuggingPriority="750" tag="3" id="W4G-N2-vlQ">
-                                                                                <rect key="frame" x="307" y="5" width="110" height="28"/>
+                                                                                <rect key="frame" x="309" y="5" width="110" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="1" maxValue="9" doubleValue="5" tickMarkPosition="above" numberOfTickMarks="9" allowsTickMarkValuesOnly="YES" sliderType="linear" id="nC8-ua-GRh"/>
                                                                                 <connections>
@@ -1773,7 +1775,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="lDb-3J-COl">
-                                                                                <rect key="frame" x="408" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="411" y="95" width="66" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="Invert" id="G5A-y3-eZz">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1782,7 +1784,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <button verticalHuggingPriority="750" tag="1" id="RkH-7d-KvR">
-                                                                                <rect key="frame" x="432" y="62" width="18" height="18"/>
+                                                                                <rect key="frame" x="435" y="62" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9oe-PD-cV0">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1794,7 +1796,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <button verticalHuggingPriority="750" tag="2" id="Mij-q3-1ft">
-                                                                                <rect key="frame" x="432" y="37" width="18" height="18"/>
+                                                                                <rect key="frame" x="435" y="37" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ydK-qV-DP4">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1805,7 +1807,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <button verticalHuggingPriority="750" tag="3" id="4rq-kh-t8s">
-                                                                                <rect key="frame" x="432" y="12" width="18" height="18"/>
+                                                                                <rect key="frame" x="435" y="12" width="18" height="18"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Rfi-FX-Gof">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1816,7 +1818,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="3" preferredMaxLayoutWidth="102" id="13Q-Fh-Tqu">
-                                                                                <rect key="frame" x="172" y="12" width="56" height="19"/>
+                                                                                <rect key="frame" x="174" y="12" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="WVX-vU-OzE">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1828,7 +1830,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="3" preferredMaxLayoutWidth="102" id="3bU-6D-8YU">
-                                                                                <rect key="frame" x="237" y="11" width="56" height="19"/>
+                                                                                <rect key="frame" x="239" y="11" width="56" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="I6z-YY-E7o">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1840,7 +1842,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="2" preferredMaxLayoutWidth="102" id="1GJ-OV-hV7">
-                                                                                <rect key="frame" x="470" y="36" width="63" height="19"/>
+                                                                                <rect key="frame" x="478" y="36" width="69" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="pSA-6B-yWO">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1852,7 +1854,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="1" preferredMaxLayoutWidth="102" id="xDF-IA-bBh">
-                                                                                <rect key="frame" x="470" y="62" width="63" height="19"/>
+                                                                                <rect key="frame" x="478" y="62" width="69" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="8hh-S6-be0">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1865,7 +1867,7 @@
                                                                                 </connections>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="evc-ST-hPR">
-                                                                                <rect key="frame" x="469" y="95" width="66" height="14"/>
+                                                                                <rect key="frame" x="477" y="95" width="72" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="center" title="VCP list" id="D9t-vT-gNJ">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1874,7 +1876,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField autoresizesSubviews="NO" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" tag="3" preferredMaxLayoutWidth="102" id="l9M-iL-Kth">
-                                                                                <rect key="frame" x="470" y="11" width="63" height="19"/>
+                                                                                <rect key="frame" x="478" y="11" width="69" height="19"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="center" bezelStyle="round" id="ANQ-Hz-2pj">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1890,27 +1892,27 @@
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="cs7-ty-i3Y">
-                                                                                <rect key="frame" x="0.0" y="85" width="549" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="85" width="563" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="H0Q-BF-CRm">
-                                                                                <rect key="frame" x="0.0" y="182" width="549" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="182" width="563" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="Iee-Pu-9P6">
-                                                                                <rect key="frame" x="0.0" y="119" width="549" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="119" width="563" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box verticalHuggingPriority="750" boxType="separator" id="8E8-uG-1Fi">
-                                                                                <rect key="frame" x="0.0" y="243" width="549" height="5"/>
+                                                                                <rect key="frame" x="0.0" y="243" width="563" height="5"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <box horizontalHuggingPriority="750" boxType="separator" id="Lwb-97-PiW">
-                                                                                <rect key="frame" x="459" y="6" width="5" height="102"/>
+                                                                                <rect key="frame" x="463" y="6" width="5" height="102"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             </box>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="WZ8-R0-wSk">
-                                                                                <rect key="frame" x="10" y="218" width="206" height="14"/>
+                                                                                <rect key="frame" x="10" y="218" width="222" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Override audio device name:" id="H9X-it-sXs">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1919,7 +1921,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="z0P-UW-eeF">
-                                                                                <rect key="frame" x="17" y="259" width="199" height="14"/>
+                                                                                <rect key="frame" x="10" y="259" width="222" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Combined dimming switchover point:" id="zv8-pZ-OPy">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1928,7 +1930,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <button verticalHuggingPriority="750" id="PJz-Jc-hZ4">
-                                                                                <rect key="frame" x="227" y="132" width="309" height="16"/>
+                                                                                <rect key="frame" x="241" y="132" width="308" height="16"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="check" title="Longer delay during DDC read operations" bezelStyle="regularSquare" imagePosition="left" controlSize="small" enabled="NO" inset="2" id="pF5-Sw-7BR">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1954,7 +1956,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <slider verticalHuggingPriority="750" tag="1" id="9H1-0z-xsx">
-                                                                                <rect key="frame" x="307" y="56" width="110" height="28"/>
+                                                                                <rect key="frame" x="309" y="56" width="110" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="1" maxValue="9" doubleValue="5" tickMarkPosition="above" numberOfTickMarks="9" allowsTickMarkValuesOnly="YES" sliderType="linear" id="HPs-Bd-Ymf"/>
                                                                                 <accessibility description="Brightness"/>
@@ -1963,7 +1965,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <slider verticalHuggingPriority="750" tag="1" id="OG9-iA-jK1">
-                                                                                <rect key="frame" x="226" y="249" width="208" height="28"/>
+                                                                                <rect key="frame" x="240" y="249" width="208" height="28"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <sliderCell key="cell" state="on" alignment="left" minValue="-8" maxValue="7" tickMarkPosition="above" numberOfTickMarks="16" allowsTickMarkValuesOnly="YES" sliderType="linear" id="c6i-bm-1LB"/>
                                                                                 <accessibility description="Brightness"/>
@@ -1972,7 +1974,7 @@
                                                                                 </connections>
                                                                             </slider>
                                                                             <button verticalHuggingPriority="750" id="veV-At-I0T">
-                                                                                <rect key="frame" x="434" y="209" width="105" height="31"/>
+                                                                                <rect key="frame" x="448" y="209" width="105" height="31"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <buttonCell key="cell" type="push" title="Get current" bezelStyle="rounded" alignment="center" controlSize="small" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hkC-vq-IcD">
                                                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1983,7 +1985,7 @@
                                                                                 </connections>
                                                                             </button>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="YRZ-Kw-qqG">
-                                                                                <rect key="frame" x="337" y="158" width="63" height="14"/>
+                                                                                <rect key="frame" x="351" y="158" width="63" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="count:" id="Orv-yj-Nad">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1992,7 +1994,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1ct-qM-zrz">
-                                                                                <rect key="frame" x="438" y="259" width="97" height="14"/>
+                                                                                <rect key="frame" x="452" y="259" width="97" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="(Gamma-&gt;DDC)" id="Bid-UL-blc">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -2003,7 +2005,7 @@
                                                                         </subviews>
                                                                     </view>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="549" id="VEg-M2-Y3v"/>
+                                                                        <constraint firstAttribute="width" constant="563" id="VEg-M2-Y3v"/>
                                                                         <constraint firstAttribute="height" constant="315" id="qRf-Ll-HYh"/>
                                                                     </constraints>
                                                                     <shadow key="shadow" blurRadius="2">
@@ -2011,6 +2013,7 @@
                                                                     </shadow>
                                                                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    <font key="titleFont" metaFont="smallSystem"/>
                                                                 </box>
                                                             </subviews>
                                                             <constraints>
@@ -2091,7 +2094,7 @@
                     </connections>
                 </viewController>
             </objects>
-            <point key="canvasLocation" x="301" y="1796"/>
+            <point key="canvasLocation" x="300.5" y="1795.5"/>
         </scene>
         <!--About Prefs View Controller-->
         <scene sceneID="Ot2-lL-eIg">

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -1033,7 +1033,6 @@
                                             </constraints>
                                             <color key="borderColor" red="1" green="1" blue="1" alpha="0.14738301570628254" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="fillColor" red="0.59607843137254901" green="0.59607843137254901" blue="0.61568627450980395" alpha="0.15133397108843538" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <font key="titleFont" metaFont="smallSystem"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="I9B-dr-BOu" column="ZC2-Ja-sIb" xPlacement="trailing" id="bAf-Bt-a5c">
@@ -1264,7 +1263,6 @@
                                             </constraints>
                                             <color key="borderColor" red="1" green="1" blue="1" alpha="0.14738301570000001" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="fillColor" red="0.59607843140000005" green="0.59607843140000005" blue="0.61568627450000002" alpha="0.15133397109999999" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <font key="titleFont" metaFont="smallSystem"/>
                                         </box>
                                     </gridCell>
                                     <gridCell row="LHa-CM-c46" column="ZC2-Ja-sIb" id="4xC-rW-7Hz"/>
@@ -1456,7 +1454,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="aUB-dZ-Kbz">
                                                                     <rect key="frame" x="78" y="419" width="115" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Identifier:" id="YqZ-LS-YvR">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Identifier:" id="YqZ-LS-YvR">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1469,7 +1467,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="vfj-lR-QtG">
                                                                     <rect key="frame" x="78" y="386" width="115" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Display type:" id="lSJ-6w-KJ2">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Display type:" id="lSJ-6w-KJ2">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1538,7 +1536,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="1PG-t6-jkR">
                                                                     <rect key="frame" x="78" y="355" width="115" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Control method:" id="PaK-1f-DsW">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Control method:" id="PaK-1f-DsW">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1674,7 +1672,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="NEl-Fq-xdB">
-                                                                                <rect key="frame" x="10" y="65" width="79" height="14"/>
+                                                                                <rect key="frame" x="5" y="65" width="84" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Brightness:" id="Bhb-6l-uPQ">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1719,7 +1717,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="xP6-gl-gpD">
-                                                                                <rect key="frame" x="10" y="39" width="79" height="14"/>
+                                                                                <rect key="frame" x="5" y="39" width="84" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Volume:" id="FER-Ri-4UO">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -1728,7 +1726,7 @@
                                                                                 </textFieldCell>
                                                                             </textField>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="9qU-4J-Zng">
-                                                                                <rect key="frame" x="10" y="14" width="79" height="14"/>
+                                                                                <rect key="frame" x="5" y="14" width="84" height="14"/>
                                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="Contrast:" id="MMk-S2-yJN">
                                                                                     <font key="font" metaFont="smallSystem"/>
@@ -2013,7 +2011,6 @@
                                                                     </shadow>
                                                                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                    <font key="titleFont" metaFont="smallSystem"/>
                                                                 </box>
                                                             </subviews>
                                                             <constraints>

--- a/MonitorControl/UI/de.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/de.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/de.lproj/Localizable.strings
+++ b/MonitorControl/UI/de.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Kurzbefehle sind nicht verfügbar";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Erzwungen)";
+"Software (gamma, forced)" = "Software (Gamma, Erzwungen)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Schattierung)";
+"Software (shade)" = "Software (Schattierung)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Dieser Bildschirm ermöglicht eine Software-Helligkeitssteuerung über gammable Manipulation, da er keine Hardware-Steuerung unterstützt. Gründe dafür können die Verwendung des HDMI-Anschlusses eines Mac mini (der die Hardware-DDC-Steuerung blockiert) oder ein Bildschirm auf der Sperrliste sein.";

--- a/MonitorControl/UI/de.lproj/Main.strings
+++ b/MonitorControl/UI/de.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Kurzbefehle aufnehmen:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "Steuerung von Helligkeit und Kontrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/UI/en.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/en.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/en.lproj/Localizable.strings
+++ b/MonitorControl/UI/en.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Shortcuts not available";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Display type:";

--- a/MonitorControl/UI/es-419.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/es-419.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/es-419.lproj/Localizable.strings
+++ b/MonitorControl/UI/es-419.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Atajos no disponibles";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/es-419.lproj/Main.strings
+++ b/MonitorControl/UI/es-419.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Tipo de pantalla:";

--- a/MonitorControl/UI/fr.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/fr.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl vous permet de contrôler la luminosité et le volume des écrans externes";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl recherche des nouvelles versions et des mises à jour de sécurité.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "Si vous refusez ces connexions, vous ne serez pas informé des nouvelles versions et des mises à jour de sécurité. Les mises à jour de sécurité sont importantes pour se défendre contre les attaques de logiciels malveillants.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl recherche des nouvelles versions et des mises à jour de sécurité.";

--- a/MonitorControl/UI/fr.lproj/Localizable.strings
+++ b/MonitorControl/UI/fr.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Raccourcis non disponible";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Logiciel (Gamma)";
+"Software (gamma)" = "Logiciel (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Logiciel (Gamma, Forcé)";
+"Software (gamma, forced)" = "Logiciel (Gamma, Forcé)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Logiciel (Voile)";
+"Software (shade)" = "Logiciel (Voile)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Cet écran permet un contrôle de la luminosité logiciel via une manipulation des tables gamma car il ne prend pas en charge le contrôle matériel. Cela peut être dû à l'utilisation du port HDMI d'un Mac mini (qui bloque le contrôle DDC matériel) ou à un écran sur liste noire.";

--- a/MonitorControl/UI/fr.lproj/Main.strings
+++ b/MonitorControl/UI/fr.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Enregistrer les raccourcis clavier :";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "Contrôle de la luminosité et du contraste :";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/UI/hu.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/hu.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "A MonitorControl a külső kijelző fényerejének és hangerejének beállítását teszi lehetővé";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "A MonitorControl ellenőrzi új verziók és biztonsági frissítések meglétét.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "Ha elutasítja ezeket a kapcsolatokat, nem értesül új verziókról és biztonsági frissítésekről. A biztonsági frissítések fontosak a rosszindulatú támadások elhárítása érdekében.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "A MonitorControl ellenőrzi új verziók és biztonsági frissítések meglétét.";

--- a/MonitorControl/UI/hu.lproj/Localizable.strings
+++ b/MonitorControl/UI/hu.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Gyorsbillentyűk nem elérhetők";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Szoftver (gamma)";
+"Software (gamma)" = "Szoftver (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Szoftver (erőltetett)";
+"Software (gamma, forced)" = "Szoftver (erőltetett)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Szoftver (árnyékolás)";
+"Software (shade)" = "Szoftver (árnyékolás)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Ez a kijelző nem támogatja a hardveres vezérlést, hanem szoftveres fényerővezérlést tesz lehetővé gamma táblázat manipulálás segítségével. Ennek okai lehetnek a nem támogatott kimenet (pl. Mac mini HDMI kimenet) vagy feketelistára helyezett kijelző használata.";

--- a/MonitorControl/UI/hu.lproj/Main.strings
+++ b/MonitorControl/UI/hu.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Rögzítés:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "Fényerő és kontraszt vezérlés:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/UI/it.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/it.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
-"ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
+"ApplicationDescription" = "MonitorControl ti permette di controllare la luminosità ed il volume del tuo monitor esterno";
 
 /* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
+"SoftwareUpdatePurpose" = "MonitorControl verifica la presenza di nuove versioni ed aggiornamenti di sicurezza";
 
 /* Sofware update deny consequences */
-"SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+"SoftwareUpdateDenyConsequences" = "Se blocchi queste connessioni, non sarai avvisato sulle nuove versioni e sugli aggiornamenti di sicurezza che sono importanti per difendersi dagli attacchi di malware.";

--- a/MonitorControl/UI/it.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/it.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl ti permette di controllare la luminosità ed il volume del tuo monitor esterno";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl verifica la presenza di nuove versioni ed aggiornamenti di sicurezza";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "Se blocchi queste connessioni, non sarai avvisato sulle nuove versioni e sugli aggiornamenti di sicurezza che sono importanti per difendersi dagli attacchi di malware.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl verifica la presenza di nuove versioni ed aggiornamenti di sicurezza";

--- a/MonitorControl/UI/it.lproj/Localizable.strings
+++ b/MonitorControl/UI/it.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Abbreviazioni non disponibili";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forzata)";
+"Software (gamma, forced)" = "Software (Gamma, Forzata)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Sfumatura)";
+"Software (shade)" = "Software (Sfumatura)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Questo monitor permette il controllo software della luminositò attraverso la manipolazione della gammatable e non supporta un controllo hardware. Un motivo potrebbe essere Reasons l'utilizzo della porta HDMI su un Mac Mini (che blocca il controllo hardware DCC) oppure avere un monitor non supportato.";

--- a/MonitorControl/UI/it.lproj/Localizable.strings
+++ b/MonitorControl/UI/it.lproj/Localizable.strings
@@ -8,22 +8,22 @@
 "Apple Silicon" = "Apple Silicon";
 
 /* Shown in the alert dialog */
-"Are you sure you want to enable a longer delay? Doing so may freeze your system and require a restart. Start at login will be disabled as a safety measure." = "Sei sicuro di voler abilitare un delay più lungo? Ciò potrebbe causare un freeze del sistema e richeidere un riavvio. L'avvio al login sarà disabilitato per sicurezza.";
+"Are you sure you want to enable a longer delay? Doing so may freeze your system and require a restart. Start at login will be disabled as a safety measure." = "Sei sicuro di voler attivare un ritardo più lungo? Facendolo potresti bloccare il sistema e dover riavviare. L'avvio automatico al login verrà disabilitaco come misura di sicurezza.";
 
 /* Shown in the alert dialog */
 "Are you sure you want to reset all preferences?" = "Sei sicuro di voler resettare tutte le preferenze?";
 
-/* Sown in menu */
+/* Shown in menu */
 "Brightness" = "Luminosità";
 
 /* Build */
 "Build" = "Build";
 
 /* Shown in the Display Preferences */
-"Built-in Display" = "Monitor Built-in";
+"Built-in Display" = "Monitor Integrato";
 
 /* Shown in menu */
-"Check for updates..." = "Check for updates...";
+"Check for updates..." = "Controlla aggiornamneti...";
 
 /* Shown in menu */
 "Contrast" = "Contrasto";
@@ -35,10 +35,10 @@
 "Displays" = "Monitor";
 
 /* Shown in the alert dialog */
-"Enable Longer Delay?" = "Abilitare Delay più Lungo?";
+"Enable Longer Delay?" = "Abilito un ritardo più lungo?";
 
 /* Shown in the Display Preferences */
-"External Display" = "Monitor esterno";
+"External Display" = "Monitor Esterno";
 
 /* Shown in the main prefs window */
 "General" = "Generale";
@@ -50,87 +50,85 @@
 "Hardware (DDC)" = "Hardware (DDC)";
 
 /* Shown in the alert dialog */
-"Incompatible previous version" = "Incompatible previous version";
+"Incompatible previous version" = "Versione precedente incompatibile";
 
 /* Intel designation (shown after the version number in Preferences) */
 "Intel" = "Intel";
 
 /* Shown in the main prefs window */
-"Keyboard" = "Keyboard";
+"Keyboard" = "Tastiera";
 
 /* Shown in the alert dialog */
 "No" = "No";
 
 /* Shown in the Display Preferences */
-"No Control" = "No Control";
+"No Control" = "Nessun Controllo";
 
 /* Shown in the Display Preferences */
-"Other Display" = "Altri monitor";
+"Other Display" = "Altri Monitor";
 
 /* Shown in the alert dialog */
-"Preferences for an incompatible previous app version detected. Default preferences are reloaded." = "Preferences for an incompatible previous app version detected. Default preferences are reloaded.";
+"Preferences for an incompatible previous app version detected. Default preferences are reloaded." = "Le impostazioni di una versione precedente incompatibile sono state trovate. Verranno caricate le impostazioni di default.";
 
 /* Shown in menu */
-"Preferences..." = "Preferences...";
+"Preferences..." = "Preferenze...";
 
 /* Shown in menu */
-"Quit" = "Quit";
+"Quit" = "Esci";
 
 /* Shown in the alert dialog */
-"Reset Preferences?" = "Resettare Preferenze?";
+"Reset Preferences?" = "Resetto le preferenze?";
 
 /* Shown in the alert dialog */
-"Safe Mode Activated" = "Safe Mode attivata";
+"Safe Mode Activated" = "Safe Mode Attivato";
 
 /* Shown in the alert dialog */
-"Shift was pressed during launch. MonitorControl started in safe mode. Default preferences are reloaded, DDC read is blocked." = "Il tasto shift è stato premuto durante l'avvio. MonitorControl avviato in safe mode. Verranno caricate le impostazioni di default, la lettura DDC è bloccata.";
+"Shift was pressed during launch. MonitorControl started in safe mode. Default preferences are reloaded, DDC read is blocked." = "Il tasto Maiuscole è stato premuto all'avvio. MonitorControl è stato avviato in modalità sicura. Preferenze di default, lettura DDC bloccata.";
 
 /* Shown in the alert dialog */
-"Shortcuts not available" = "Comandi rapidi non disponibili";
+"Shortcuts not available" = "Abbreviazioni non disponibili";
 
 /* Shown in the Display Preferences */
 "Software (Gamma)" = "Software (Gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (Gamma, Forced)" = "Software (Gamma, Forzata)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (Shade)" = "Software (Sfumatura)";
 
 /* Shown in the Display Preferences */
-"This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";
+"This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Questo monitor permette il controllo software della luminositò attraverso la manipolazione della gammatable e non supporta un controllo hardware. Un motivo potrebbe essere Reasons l'utilizzo della porta HDMI su un Mac Mini (che blocca il controllo hardware DCC) oppure avere un monitor non supportato.";
 
 /* Shown in the Display Preferences */
-"This display has an unspecified control status." = "This display has an unspecified control status.";
+"This display has an unspecified control status." = "Questo monitor ha uno stato di controllo non specificato.";
 
 /* Shown in the Display Preferences */
-"This display is reported to support hardware DDC control but the current settings allow for software control only." = "This display is reported to support hardware DDC control but the current settings allow for software control only.";
+"This display is reported to support hardware DDC control but the current settings allow for software control only." = "Questo monitor supporta il controllo DDC hardware ma le impostazioni correnti consentono solo quello software.";
 
 /* Shown in the Display Preferences */
-"This display is reported to support hardware DDC control. If you encounter issues, you can disable hardware DDC control to force software control." = "This display is reported to support hardware DDC control. If you encounter issues, you can disable hardware DDC control to force software control.";
+"This display is reported to support hardware DDC control. If you encounter issues, you can disable hardware DDC control to force software control." = "Questo monitor supporta il controllo DDC hardware. Se rilevi dei problemi, puoi disabilitarlo e forzare il controllo software.";
 
 /* Shown in the Display Preferences */
-"This display supports native Apple brightness protocol. This allows macOS to control this display without MonitorControl as well." = "This display supports native Apple brightness protocol. This allows macOS to control this display without MonitorControl as well.";
+"This display supports native Apple brightness protocol. This allows macOS to control this display without MonitorControl as well." = "Questo monitor supporta il protocollo nativo Apple della luminosità. Questo permette al macOS di controllare il monitor anhe senza l'utilizzo di MonitorControl.";
 
 /* Shown in the Display Preferences */
-"This is a virtual display (examples: AirPlay, Sidecar, display connected via a DisplayLink Dock or similar) which does not allow hardware or software gammatable control. Shading is used as a substitute but only in non-mirror scenarios. Mouse cursor will be unaffected and artifacts may appear when entering/leaving full screen mode." = "This is a virtual display (examples: AirPlay, Sidecar, display connected via a DisplayLink Dock or similar) which does not allow hardware or software gammatable control. Shading is used as a substitute but only in non-mirror scenarios. Mouse cursor will be unaffected and artifacts may appear when entering/leaving full screen mode.";
+"This is a virtual display (examples: AirPlay, Sidecar, display connected via a DisplayLink Dock or similar) which does not allow hardware or software gammatable control. Shading is used as a substitute but only in non-mirror scenarios. Mouse cursor will be unaffected and artifacts may appear when entering/leaving full screen mode." = "Questo monitor è un di tipo virtuale (esempio: AirPlay, Sidecar, connessione via via DisplayLink Dock o simili) e non consente il controllo hardware o software della gammatable. La sfumatura è utilizzata in sostituzione ma solo in modalità non duplicazione. Il cursore del mouse non rimane invariato e si potrebbero verificare artefatti entrando/uscendo dalla modalità a pieno schermo.";
 
-/* Unknown display name
- Unknown model
- Unknown vendor */
+/* Unknown display name */
 "Unknown" = "Sconosciuto";
 
 /* Version */
 "Version" = "Versione";
 
 /* Shown in the Display Preferences */
-"Virtual Display" = "Monitor virtuale";
+"Virtual Display" = "Monitor Virtuale";
 
 /* Shown in menu */
 "Volume" = "Volume";
 
 /* Shown in the alert dialog */
-"Yes" = "Sì";
+"Yes" = "Si";
 
 /* Shown in the alert dialog */
-"You need to enable MonitorControl in System Preferences > Security and Privacy > Accessibility for the keyboard shortcuts to work" = "E' necessario abilitare MonitorControl nelle Preferenze di Sistema > Sicurezza e Privacy > Accessibilità affinchè le abbreviazioni da tastiera funzionino";
+"You need to enable MonitorControl in System Preferences > Security and Privacy > Accessibility for the keyboard shortcuts to work" = "Devi abilitare MonitorControl nelle Preferenze di Sistema > Sicurezza e Privacy > Accessibilità affinchè le abbreviazioni da tastiera funzionino";

--- a/MonitorControl/UI/it.lproj/Main.strings
+++ b/MonitorControl/UI/it.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Registra abbreviazioni:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "Controllo luminosità e contrasto:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/UI/it.lproj/Main.strings
+++ b/MonitorControl/UI/it.lproj/Main.strings
@@ -1,302 +1,302 @@
 /* Class = "NSButtonCell"; title = "Sync brightness changes from Built-in and Apple displays"; ObjectID = "0ca-DG-AgB"; */
-"0ca-DG-AgB.title" = "Sync brightness changes from Built-in and Apple displays";
+"0ca-DG-AgB.title" = "Sincronizza le modifiche dai monitor Incorporati ed Apple ";
 
 /* Class = "NSButtonCell"; title = "Attempt to read display settings"; ObjectID = "0qp-fq-8MI"; */
-"0qp-fq-8MI.title" = "Attempt to read display settings";
+"0qp-fq-8MI.title" = "Tenta di leggere le impostazioni del monitor";
 
 /* Class = "NSTextFieldCell"; title = "MonitorControl"; ObjectID = "1PJ-14-Bvn"; */
 "1PJ-14-Bvn.title" = "MonitorControl";
 
 /* Class = "NSMenuItem"; title = "Standard keyboard volume and mute keys"; ObjectID = "1sy-Kd-WL5"; */
-"1sy-Kd-WL5.title" = "Standard keyboard volume and mute keys";
+"1sy-Kd-WL5.title" = "Tasti standard per volume e mute";
 
 /* Class = "NSButtonCell"; title = "Change volume for all screens"; ObjectID = "1XT-3S-UuD"; */
-"1XT-3S-UuD.title" = "Change volume for all screens";
+"1XT-3S-UuD.title" = "Cambia il volume per tutti i monitor";
 
 /* Class = "NSTextFieldCell"; title = "DDC min"; ObjectID = "1zE-fg-xEm"; */
-"1zE-fg-xEm.title" = "DDC min";
+"1zE-fg-xEm.title" = "Min DDC";
 
 /* Class = "NSMenuItem"; title = "Custom keyboard shortcuts"; ObjectID = "4CG-0I-anB"; */
-"4CG-0I-anB.title" = "Custom keyboard shortcuts";
+"4CG-0I-anB.title" = "Abreviazioni da tastiera personalizzate";
 
 /* Class = "NSTextFieldCell"; title = "MonitorControl uses mouse position to determine which display to control. Using window focus instead might not work well with full screen apps."; ObjectID = "4dX-o1-xAc"; */
-"4dX-o1-xAc.title" = "MonitorControl uses mouse position to determine which display to control. Using window focus instead might not work well with full screen apps.";
+"4dX-o1-xAc.title" = "MonitorControl utilizza la posizione del mouse per determinare il monitor da controllare. L'utilizzo del focus sulla finestra potrebbe non funzionare sulle applicazioni a pieno schermo.";
 
 /* Class = "NSButtonCell"; title = "Show separate controls for each display in menu"; ObjectID = "4t2-Rv-njr"; */
-"4t2-Rv-njr.title" = "Show separate controls for each display in menu";
+"4t2-Rv-njr.title" = "Mostra slider separati per ciascun monitor nel menu";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "Brightness"; ObjectID = "567-le-fLg"; */
-"567-le-fLg.ibExternalAccessibilityDescription" = "Brightness";
+"567-le-fLg.ibExternalAccessibilityDescription" = "Luminosità";
 
 /* Class = "NSButtonCell"; title = "Reset Preferences"; ObjectID = "5yT-5F-X5R"; */
-"5yT-5F-X5R.title" = "Reset Preferences";
+"5yT-5F-X5R.title" = "Resetta le Preferenze";
 
 /* Class = "NSMenuItem"; title = "Always hide"; ObjectID = "6mo-7S-oOO"; */
-"6mo-7S-oOO.title" = "Always hide";
+"6mo-7S-oOO.title" = "Nascondi sempre";
 
 /* Class = "NSTextFieldCell"; title = "Slider behavior:"; ObjectID = "75n-7M-1mS"; */
-"75n-7M-1mS.title" = "Slider behavior:";
+"75n-7M-1mS.title" = "Comportamento slider:";
 
 /* Class = "NSButtonCell"; title = "Use combined slider for all displays"; ObjectID = "7rn-Lu-fcl"; */
-"7rn-Lu-fcl.title" = "Use combined slider for all displays";
+"7rn-Lu-fcl.title" = "Utlizza uno slider combinato per tutti i monitor";
 
 /* Class = "NSButtonCell"; title = "Show slider tick marks"; ObjectID = "7zf-m1-gJO"; */
-"7zf-m1-gJO.title" = "Show slider tick marks";
+"7zf-m1-gJO.title" = "Mostra i marcatori nello slider";
 
 /* Class = "NSTextFieldCell"; title = "Slider knob will snap to 0%, 25%, 50%, 75% and 100% when in proximity making setting these values easier. Disable for finer control."; ObjectID = "8Gx-Ya-zhp"; */
-"8Gx-Ya-zhp.title" = "Slider knob will snap to 0%, 25%, 50%, 75% and 100% when in proximity making setting these values easier. Disable for finer control.";
+"8Gx-Ya-zhp.title" = "Lo slider scatta nele posizioni 0%, 25%, 50%, 75% e 100% quando si trova in prossimità di questi valori in modo da impostarli più semplicemente.";
 
 /* Class = "NSButtonCell"; title = "Use fine OSD scale"; ObjectID = "8Q8-57-xnT"; */
-"8Q8-57-xnT.title" = "Use fine OSD scale";
+"8Q8-57-xnT.title" = "Utilizza la scala fine OSD";
 
 /* Class = "NSButtonCell"; title = "Special thanks to our contributors!"; ObjectID = "95V-M4-2l5"; */
-"95V-M4-2l5.title" = "Ringraziamenti speciali ai nostri contributori!";
+"95V-M4-2l5.title" = "Ringraziamento speciale ai contributors!";
 
 /* Class = "NSMenuItem"; title = "Custom keyboard shortcuts"; ObjectID = "9eC-PD-FHl"; */
-"9eC-PD-FHl.title" = "Custom keyboard shortcuts";
+"9eC-PD-FHl.title" = "Abbreviazioni da tastiera personalizzare";
 
 /* Class = "NSSlider"; ibExternalAccessibilityDescription = "Brightness"; ObjectID = "9H1-0z-xsx"; */
-"9H1-0z-xsx.ibExternalAccessibilityDescription" = "Brightness";
+"9H1-0z-xsx.ibExternalAccessibilityDescription" = "Luminosità";
 
 /* Class = "NSTextFieldCell"; title = "Show tick marks at 0%, 25%, 50%, 75% and 100% for accuracy."; ObjectID = "A8P-vn-DEJ"; */
-"A8P-vn-DEJ.title" = "Show tick marks at 0%, 25%, 50%, 75% and 100% for accuracy.";
+"A8P-vn-DEJ.title" = "Mostra i marcatori a 0%, 25%, 50%, 75% and 100%.";
 
 /* Class = "NSButtonCell"; title = "Disable software dimming as fallback"; ObjectID = "afB-Xx-Lta"; */
-"afB-Xx-Lta.title" = "Disable software dimming as fallback";
+"afB-Xx-Lta.title" = "Disabilità l'attenuazione software come fallback";
 
 /* Class = "NSTextFieldCell"; title = "Use brightness, volume and other settings from last time or use defaults. Values will be applied to the display upon first change by the user."; ObjectID = "an7-Aj-3fZ"; */
-"an7-Aj-3fZ.title" = "Use brightness, volume and other settings from last time or use defaults. Values will be applied to the display upon first change by the user.";
+"an7-Aj-3fZ.title" = "Utilizza la luminisità, il volume ed altre impostazioni dell'ultima volta o utilizza il default. I valori saranno applicati al monitor alla prima modifica dell'utente.";
 
 /* Class = "NSTextFieldCell"; title = "Brightness:"; ObjectID = "Bhb-6l-uPQ"; */
-"Bhb-6l-uPQ.title" = "Brightness:";
+"Bhb-6l-uPQ.title" = "Luminosità:";
 
 /* Class = "NSTextFieldCell"; title = "(Gamma->DDC)"; ObjectID = "Bid-UL-blc"; */
 "Bid-UL-blc.title" = "(Gamma->DDC)";
 
 /* Class = "NSTextFieldCell"; title = "For hardware (DDC) controlled displays only. Results may vary."; ObjectID = "bIe-6O-xEH"; */
-"bIe-6O-xEH.title" = "For hardware (DDC) controlled displays only. Results may vary.";
+"bIe-6O-xEH.title" = "Solo per i montor con controllo hardware (DDC). I risultati possono variare.";
 
 /* Class = "NSButtonCell"; title = "Disable macOS volume OSD"; ObjectID = "bkM-Px-U3b"; */
-"bkM-Px-U3b.title" = "Disabilita volume OSD di macOS";
+"bkM-Px-U3b.title" = "Disabilita l'OSD del volumme del macOS";
 
 /* Class = "NSTextFieldCell"; title = "OSD scale:"; ObjectID = "bP4-GJ-vhJ"; */
-"bP4-GJ-vhJ.title" = "OSD scale:";
+"bP4-GJ-vhJ.title" = "Scala OSD:";
 
 /* Class = "NSButtonCell"; title = "Reset settings"; ObjectID = "BYS-7Y-bRz"; */
-"BYS-7Y-bRz.title" = "Resetta preferenze";
+"BYS-7Y-bRz.title" = "Reset impostazioni";
 
 /* Class = "NSButtonCell"; title = "Enable Mute DDC command"; ObjectID = "bZq-0d-lJa"; */
-"bZq-0d-lJa.title" = "Abilità comando Muto DDC";
+"bZq-0d-lJa.title" = "Abilita il comando Mute DDC";
 
 /* Class = "NSTextFieldCell"; title = "Decrease:"; ObjectID = "Bzq-Co-fex"; */
-"Bzq-Co-fex.title" = "Decrease:";
+"Bzq-Co-fex.title" = "Diminuisci:";
 
 /* Class = "NSButtonCell"; title = "Show volume slider in menu"; ObjectID = "c9D-MB-lma"; */
-"c9D-MB-lma.title" = "Show volume slider in menu";
+"c9D-MB-lma.title" = "Mostra lo slider del volume nel menu";
 
 /* Class = "NSMenuItem"; title = "Custom"; ObjectID = "Cle-DD-vR7"; */
-"Cle-DD-vR7.title" = "Custom";
+"Cle-DD-vR7.title" = "Personalizzato";
 
 /* Class = "NSButtonCell"; title = "Website"; ObjectID = "Cln-uW-2dd"; */
 "Cln-uW-2dd.title" = "Sito web";
 
 /* Class = "NSTextFieldCell"; title = "Upon startup or wake:"; ObjectID = "cNt-Cq-vK4"; */
-"cNt-Cq-vK4.title" = "Upon startup or wake:";
+"cNt-Cq-vK4.title" = "All'avvio o alla riattivazione:";
 
 /* Class = "NSTextFieldCell"; title = "⚠️ Warning! Changing some of these settings may cause system freezes or unexpected behavior!"; ObjectID = "Cz1-Mh-llk"; */
-"Cz1-Mh-llk.title" = "⚠️ Attenzione! La modifica di queste opzioni può causare freeze di sistema o comportamenti inattesi!";
+"Cz1-Mh-llk.title" = "⚠️ Attenzione! modificando queste impostazioni si può causare il blocco del sistema o comportamenti inattesi!";
 
 /* Class = "NSTextFieldCell"; title = "Alternative keys are the F14/F15 (Scroll Lock and Pause on PC keyboards, brightness keys on some Logitech keyboards)."; ObjectID = "D4H-hU-FLn"; */
-"D4H-hU-FLn.title" = "Alternative keys are the F14/F15 (Scroll Lock and Pause on PC keyboards, brightness keys on some Logitech keyboards).";
+"D4H-hU-FLn.title" = "Tasti alternativi sono F14/F15 (Blocco Scorr e Pausa nella tastiera PC , tasti luminosità su alcune tastiere Logitech).";
 
 /* Class = "NSTextFieldCell"; title = "VCP list"; ObjectID = "D9t-vT-gNJ"; */
-"D9t-vT-gNJ.title" = "VCP list";
+"D9t-vT-gNJ.title" = "Lista VCP";
 
 /* Class = "NSTextFieldCell"; title = "Without this the app uses mouse position to determine which display to control. You can override audio device name under Displays if needed."; ObjectID = "Dha-Tm-cDM"; */
-"Dha-Tm-cDM.title" = "Without this the app uses mouse position to determine which display to control. You can override audio device name under Displays if needed.";
+"Dha-Tm-cDM.title" = "Senza questo l'app utlizza la posizione del mouse per determinare il display da controllare. Puoi sovrascrivere il nome del dispositivo audio dentro Monitor se necessario.";
 
 /* Class = "NSTextFieldCell"; title = "You can disable smooth transitions for a more direct, immediate control."; ObjectID = "ENt-mP-0yH"; */
-"ENt-mP-0yH.title" = "You can disable smooth transitions for a more direct, immediate control.";
+"ENt-mP-0yH.title" = "Puoi disabilitare le transizioni modbide per un controllo più diretto ed immediato.";
 
 /* Class = "NSMenuItem"; title = "Minimal"; ObjectID = "Eq3-z9-yIo"; */
-"Eq3-z9-yIo.title" = "Minimale";
+"Eq3-z9-yIo.title" = "Minimalista";
 
 /* Class = "NSTextFieldCell"; title = "Increase:"; ObjectID = "eue-as-VOR"; */
-"eue-as-VOR.title" = "Increase:";
+"eue-as-VOR.title" = "Aumenta:";
 
 /* Class = "NSTextFieldCell"; title = "Scale mapping curve"; ObjectID = "Eui-5S-JR6"; */
-"Eui-5S-JR6.title" = "Scale mapping curve";
+"Eui-5S-JR6.title" = "Curva mappatura";
 
 /* Class = "NSTextFieldCell"; title = "Mute:"; ObjectID = "EvN-FT-vdZ"; */
 "EvN-FT-vdZ.title" = "Mute:";
 
 /* Class = "NSTextFieldCell"; title = "Normally keyboard controls change one OSD chiclet worth of value and Shift+Option allows fine control. This makes fine control default."; ObjectID = "f6J-Ui-uMB"; */
-"f6J-Ui-uMB.title" = "Normally keyboard controls change one OSD chiclet worth of value and Shift+Option allows fine control. This makes fine control default.";
+"f6J-Ui-uMB.title" = "Normalmente il controllo da tastiera cambia uno step del valore e Maiusc+Alt permette un controllo più fine. Questo imposta il controllo fine come default.";
 
 /* Class = "NSButtonCell"; title = "Reset Name"; ObjectID = "f9g-8s-gdd"; */
-"f9g-8s-gdd.title" = "Resetta Nome";
+"f9g-8s-gdd.title" = "Resetta nome";
 
 /* Class = "NSButtonCell"; title = "Automatically check for updates"; ObjectID = "Faf-9L-TXx"; */
-"Faf-9L-TXx.title" = "Automatically check for updates";
+"Faf-9L-TXx.title" = "Controlla automaticamente gli aggiornamenti";
 
 /* Class = "NSTextFieldCell"; title = "Brightness control:"; ObjectID = "fe9-Ia-t9m"; */
-"fe9-Ia-t9m.title" = "Brightness control:";
+"fe9-Ia-t9m.title" = "Controllo luminosità:";
 
 /* Class = "NSTextFieldCell"; title = "Volume:"; ObjectID = "FER-Ri-4UO"; */
 "FER-Ri-4UO.title" = "Volume:";
 
 /* Class = "NSTextFieldCell"; title = "Apple and built-in displays already have a brightness slider in Control Center."; ObjectID = "fmZ-HI-Mdc"; */
-"fmZ-HI-Mdc.title" = "Apple and built-in displays already have a brightness slider in Control Center.";
+"fmZ-HI-Mdc.title" = "I Monitor Apple ed incorporati hanno già lo slider della luminosità nel Centro di Controllo.";
 
 /* Class = "NSMenuItem"; title = "None"; ObjectID = "FoA-yh-Yx3"; */
-"FoA-yh-Yx3.title" = "None";
+"FoA-yh-Yx3.title" = "Nessuno";
 
 /* Class = "NSMenuItem"; title = "Show as icons"; ObjectID = "fR3-kq-cps"; */
-"fR3-kq-cps.title" = "Show as icons";
+"fR3-kq-cps.title" = "Mostra come icone";
 
 /* Class = "NSMenuItem"; title = "Show as text"; ObjectID = "fWd-Es-zsy"; */
-"fWd-Es-zsy.title" = "Show as text";
+"fWd-Es-zsy.title" = "Mostra come testo";
 
 /* Class = "NSTextFieldCell"; title = "Invert"; ObjectID = "G5A-y3-eZz"; */
-"G5A-y3-eZz.title" = "Invert";
+"G5A-y3-eZz.title" = "Inverti";
 
 /* Class = "NSTextFieldCell"; title = "Brightness slider for hardware or software controlled displays or TVs."; ObjectID = "gXH-HL-ZOL"; */
-"gXH-HL-ZOL.title" = "Brightness slider for hardware or software controlled displays or TVs.";
+"gXH-HL-ZOL.title" = "Slider luminosità per i monitor o TV controllati via hardware o software.";
 
 /* Class = "NSTextFieldCell"; title = "Override audio device name:"; ObjectID = "H9X-it-sXs"; */
-"H9X-it-sXs.title" = "Override audio device name:";
+"H9X-it-sXs.title" = "Sovrascrivi nome dispositivo audio:";
 
 /* Class = "NSTextFieldCell"; title = "Relaunch the app to access Preferences if the menu option is not accessible. Use the button below to quit the app."; ObjectID = "hF7-fM-aKr"; */
-"hF7-fM-aKr.title" = "Relaunch the app to access Preferences if the menu option is not accessible. Use the button below to quit the app.";
+"hF7-fM-aKr.title" = "Riapri l'applicazione per accedere alla preferenze se l'opzione nel menu non è accessibile. Utilizza il bottone soprastante per chudere l'applicazione.";
 
 /* Class = "NSButtonCell"; title = "Get current"; ObjectID = "hkC-vq-IcD"; */
-"hkC-vq-IcD.title" = "Get current";
+"hkC-vq-IcD.title" = "Valore corrente";
 
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "HLE-Vp-kcS"; */
-"HLE-Vp-kcS.title" = "Record shortcuts:";
+"HLE-Vp-kcS.title" = "Registra abbreviazioni:";
 
 /* Class = "NSMenuItem"; title = "Hide"; ObjectID = "HUT-Qc-kuu"; */
-"HUT-Qc-kuu.title" = "Hide";
+"HUT-Qc-kuu.title" = "Nascondi";
 
 /* Class = "NSTextFieldCell"; title = "Additional controls:"; ObjectID = "i5X-M5-Tf5"; */
-"i5X-M5-Tf5.title" = "Additional controls:";
+"i5X-M5-Tf5.title" = "Controlli addizionali:";
 
 /* Class = "NSTextFieldCell"; title = "Brightness"; ObjectID = "IJB-mO-e8I"; */
-"IJB-mO-e8I.title" = "Brightness";
+"IJB-mO-e8I.title" = "Luminosità";
 
 /* Class = "NSButtonCell"; title = "Enable smooth brightness transitions"; ObjectID = "IK4-u5-qjf"; */
-"IK4-u5-qjf.title" = "Enable smooth brightness transitions";
+"IK4-u5-qjf.title" = "Abilita le transizioni morbide della luminosità";
 
 /* Class = "NSButtonCell"; title = "Use fine OSD scale for volume"; ObjectID = "J3L-MW-iJL"; */
-"J3L-MW-iJL.title" = "Use fine OSD scale for volume";
+"J3L-MW-iJL.title" = "Utilizza la scala fine OSD per il volume";
 
 /* Class = "NSButtonCell"; title = "Start at Login"; ObjectID = "j72-NF-zsW"; */
-"j72-NF-zsW.title" = "Avvia MonitorControl al login";
+"j72-NF-zsW.title" = "Avvia automaticamente al Login";
 
 /* Class = "NSButtonCell"; title = "Change for all screens"; ObjectID = "JC3-pb-XnR"; */
-"JC3-pb-XnR.title" = "Change for all screens";
+"JC3-pb-XnR.title" = "Modifica per tutti i monitor";
 
 /* Class = "NSTextFieldCell"; title = "Note: you can press Shift during startup for 'Safe mode' to restore defaults and avoid reading or setting anything."; ObjectID = "Jx2-gO-nq9"; */
-"Jx2-gO-nq9.title" = "Note: you can press Shift during startup for 'Safe mode' to restore defaults and avoid reading or setting anything.";
+"Jx2-gO-nq9.title" = "Nota: puoi premere Maiusc all'avvio per il 'Safe mode' in modo da impostare i valori di default.";
 
 /* Class = "NSButtonCell"; title = "Apply last saved values to the display"; ObjectID = "K0S-zN-M4k"; */
-"K0S-zN-M4k.title" = "Apply last saved values to the display";
+"K0S-zN-M4k.title" = "Applica al monitor gli ultimi valori salvati";
 
 /* Class = "NSButtonCell"; title = "Enable for Apple branded and built-in displays as well"; ObjectID = "K6A-4z-1aQ"; */
-"K6A-4z-1aQ.title" = "Enable for Apple branded and built-in displays as well";
+"K6A-4z-1aQ.title" = "Abilita anche per i monitor Apple ed incorporati";
 
 /* Class = "NSTextFieldCell"; title = "Don't use software dimming as fallback if no hardware control is available."; ObjectID = "kgh-b4-gmO"; */
-"kgh-b4-gmO.title" = "Don't use software dimming as fallback if no hardware control is available.";
+"kgh-b4-gmO.title" = "Non utlizzare l'attenuazione software come fallback se il controllo hardware non è disponibile.";
 
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
-"kqJ-jQ-b7U.title" = "Record shortcuts:";
+"kqJ-jQ-b7U.title" = "Registra abbreviazioni:";
 
 /* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+"LO4-4k-gxY.title" = "Controllo luminosità e contrasto:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Tipo di monitor:";
 
 /* Class = "NSTextFieldCell"; title = "Screen to control:"; ObjectID = "ltL-gR-K3Z"; */
-"ltL-gR-K3Z.title" = "Screen to control:";
+"ltL-gR-K3Z.title" = "Monitor da controllare:";
 
 /* Class = "NSButtonCell"; title = "Enable slider snapping"; ObjectID = "MlU-hl-d46"; */
-"MlU-hl-d46.title" = "Enable slider snapping";
+"MlU-hl-d46.title" = "Abilita lo snap dello slider";
 
 /* Class = "NSMenuItem"; title = "Always show in the menu bar"; ObjectID = "MM0-Lf-VgF"; */
-"MM0-Lf-VgF.title" = "Always show in the menu bar";
+"MM0-Lf-VgF.title" = "Mostra sempre nella barra dei menu";
 
 /* Class = "NSButtonCell"; title = "Use window focus to determine which display to control"; ObjectID = "mMG-Ac-gdB"; */
-"mMG-Ac-gdB.title" = "Use window focus to determine which display to control";
+"mMG-Ac-gdB.title" = "Utilizza la finestra attiva per determinare il monitor da controllare";
 
 /* Class = "NSTextFieldCell"; title = "Contrast:"; ObjectID = "MMk-S2-yJN"; */
-"MMk-S2-yJN.title" = "Contrast:";
+"MMk-S2-yJN.title" = "Contrasto:";
 
 /* Class = "NSTextFieldCell"; title = "Increase:"; ObjectID = "mue-fa-8z6"; */
-"mue-fa-8z6.title" = "Increase:";
+"mue-fa-8z6.title" = "Aumenta:";
 
 /* Class = "NSButtonCell"; title = "Show brightness slider in menu"; ObjectID = "MWo-6I-s9L"; */
-"MWo-6I-s9L.title" = "Show brightness slider in menu";
+"MWo-6I-s9L.title" = "Mostra lo slider della luminositò nel menu";
 
 /* Class = "NSButtonCell"; title = "Separate scales for combined hardware & software dimming"; ObjectID = "O8o-hI-8eR"; */
-"O8o-hI-8eR.title" = "Separate scales for combined hardware & software dimming";
+"O8o-hI-8eR.title" = "Scale separate per controllo combinato della attenuazione hw/sw";
 
 /* Class = "NSButtonCell"; title = "Use audio device name to determine which display to control"; ObjectID = "OAa-B4-8r3"; */
-"OAa-B4-8r3.title" = "Use audio device name to determine which display to control";
+"OAa-B4-8r3.title" = "Utilizza dispositivo audio per determinare il monitor da controllare";
 
 /* Class = "NSSlider"; ibExternalAccessibilityDescription = "Brightness"; ObjectID = "OG9-iA-jK1"; */
-"OG9-iA-jK1.ibExternalAccessibilityDescription" = "Brightness";
+"OG9-iA-jK1.ibExternalAccessibilityDescription" = "Luminosità";
 
 /* Class = "NSMenuItem"; title = "Disable keyboard"; ObjectID = "oHf-Gh-68c"; */
-"oHf-Gh-68c.title" = "Disable keyboard";
+"oHf-Gh-68c.title" = "Disabilita tastiera";
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "okD-DG-pYa"; */
 "okD-DG-pYa.title" = "Applicazione:";
 
 /* Class = "NSMenuItem"; title = "Standard keyboard brightness keys"; ObjectID = "Oke-bW-cb1"; */
-"Oke-bW-cb1.title" = "Standard keyboard brightness keys";
+"Oke-bW-cb1.title" = "Tasti di luminosità standard";
 
 /* Class = "NSTextFieldCell"; title = "count:"; ObjectID = "Orv-yj-Nad"; */
-"Orv-yj-Nad.title" = "count:";
+"Orv-yj-Nad.title" = "conteggio:";
 
 /* Class = "NSTextFieldCell"; title = "Use the brightness keys of your Apple keyboard to control brightness. You can hold Control to adjust the built-in display, Control+Option to adjust external displays. Hold Shift+Option for fine control. Control+Option+Command adjusts contrast on DDC compatible displays."; ObjectID = "pa0-Hz-ace"; */
-"pa0-Hz-ace.title" = "Use the brightness keys of your Apple keyboard to control brightness. You can hold Control to adjust the built-in display, Control+Option to adjust external displays. Hold Shift+Option for fine control. Control+Option+Command adjusts contrast on DDC compatible displays.";
+"pa0-Hz-ace.title" = "Utilizza il tasto luminosità della tua tastiera Apple per controllare la luminosità. Puoi premere Control per il monitor incorporato, Control-Alt per i monitor esterni. Premi Maiusc+Alt per un controlllo fine. Control+Alt+Command modifica il contrasto sui monitor compatibili DDC.";
 
 /* Class = "NSTextFieldCell"; title = "Control method:"; ObjectID = "PaK-1f-DsW"; */
-"PaK-1f-DsW.title" = "Tipo di controllo:";
+"PaK-1f-DsW.title" = "Metodo di controllo:";
 
 /* Class = "NSButtonCell"; title = "Longer delay during DDC read operations"; ObjectID = "pF5-Sw-7BR"; */
-"pF5-Sw-7BR.title" = "Delay più lungo durante le operazioni di lettura DDC";
+"pF5-Sw-7BR.title" = "Ritardo più lungo durante le operazioni di lettura DDC";
 
 /* Class = "NSTextFieldCell"; title = "For hardware (DDC) controlled displays only."; ObjectID = "POy-35-bh0"; */
-"POy-35-bh0.title" = "For hardware (DDC) controlled displays only.";
+"POy-35-bh0.title" = "Solo per i monitor con controllo hardware (DDC).";
 
 /* Class = "NSTextFieldCell"; title = "DDC max"; ObjectID = "psF-vX-AFB"; */
-"psF-vX-AFB.title" = "DDC max";
+"psF-vX-AFB.title" = "Max DDC";
 
 /* Class = "NSButtonCell"; title = "Show sliders only for the display currently showing the menu"; ObjectID = "PvP-TV-OmT"; */
-"PvP-TV-OmT.title" = "Show sliders only for the display currently showing the menu";
+"PvP-TV-OmT.title" = "Mostra gli slider solo per il monitor che sta mostrando il menu";
 
 /* Class = "NSTextFieldCell"; title = "Use software dimming after the display reached zero hardware brightness for extended range. Works for DDC controlled displays only."; ObjectID = "PyY-p9-3NP"; */
-"PyY-p9-3NP.title" = "Use software dimming after the display reached zero hardware brightness for extended range. Works for DDC controlled displays only.";
+"PyY-p9-3NP.title" = "Utilizza l'attenuazione software quando il monitor ha raggiunto lo zero della luminosità hardware per estendere il range. Funziona solo per i monitor controllati via DDC.";
 
 /* Class = "NSMenuItem"; title = "Both standard and custom shortcuts"; ObjectID = "QDG-SA-mRX"; */
-"QDG-SA-mRX.title" = "Both standard and custom shortcuts";
+"QDG-SA-mRX.title" = "Entrambe le abbreviazioni standard e personalizzate";
 
 /* Class = "NSButtonCell"; title = "Quit application"; ObjectID = "qlb-wH-qr4"; */
-"qlb-wH-qr4.title" = "Quit application";
+"qlb-wH-qr4.title" = "Esci dall'appplicazione";
 
 /* Class = "NSButtonCell"; title = "Show contrast slider in menu"; ObjectID = "qO0-dB-yUs"; */
-"qO0-dB-yUs.title" = "Show contrast slider in menu";
+"qO0-dB-yUs.title" = "Mostra lo slider del contrasto nel menu";
 
 /* Class = "NSTextFieldCell"; title = "Volume control (DDC only):"; ObjectID = "qoh-Gn-f11"; */
-"qoh-Gn-f11.title" = "Volume control (DDC only):";
+"qoh-Gn-f11.title" = "Controllo volume (solo DDC):";
 
 /* Class = "NSTextFieldCell"; title = "Show percentage next to slider for more precision."; ObjectID = "qXy-CL-Wf1"; */
-"qXy-CL-Wf1.title" = "Show percentage next to slider for more precision.";
+"qXy-CL-Wf1.title" = "Mostra la percentuale vicino allo slider per una maggior precisione.";
 
 /* Class = "NSButtonCell"; title = "Combine hardware and software dimming"; ObjectID = "r76-Zc-x09"; */
-"r76-Zc-x09.title" = "Combine hardware and software dimming";
+"r76-Zc-x09.title" = "Combina l'attenuazione hardware e software";
 
 /* Class = "NSTextFieldCell"; title = "Advanced:"; ObjectID = "r7i-oG-Ab6"; */
 "r7i-oG-Ab6.title" = "Avanzate:";
@@ -305,97 +305,97 @@
 "Riq-uM-bTs.title" = "Normale";
 
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Brightness"; ObjectID = "RkH-7d-KvR"; */
-"RkH-7d-KvR.ibExternalAccessibilityDescription" = "Brightness";
+"RkH-7d-KvR.ibExternalAccessibilityDescription" = "Luminosità";
 
 /* Class = "NSButtonCell"; title = "Show advanced settings"; ObjectID = "sAR-sh-y8e"; */
-"sAR-sh-y8e.title" = "Show advanced settings";
+"sAR-sh-y8e.title" = "Mostra impostazioni avanzate";
 
 /* Class = "NSTextFieldCell"; title = "General menu items style:"; ObjectID = "thh-DG-ecH"; */
-"thh-DG-ecH.title" = "General menu items style:";
+"thh-DG-ecH.title" = "Stile elementi del menu:";
 
 /* Class = "NSTextFieldCell"; title = "@the0neyouseek\n@JoniVR\n@waydabber"; ObjectID = "TKd-J8-Iyk"; */
-"TKd-J8-Iyk.title" = "@the0neyouseek\n@reitermarkus\n@JoniVR\n@waydabber";
+"TKd-J8-Iyk.title" = "@the0neyouseek\n@JoniVR\n@waydabber";
 
 /* Class = "NSTextFieldCell"; title = "Menu Icon:"; ObjectID = "u6s-Pb-BCG"; */
-"u6s-Pb-BCG.title" = "Menu Icon:";
+"u6s-Pb-BCG.title" = "Icona menu:";
 
 /* Class = "NSTextFieldCell"; title = "Works if an audio device is selected with no native volume control."; ObjectID = "uF5-a9-Ngz"; */
-"uF5-a9-Ngz.title" = "Works if an audio device is selected with no native volume control.";
+"uF5-a9-Ngz.title" = "Funziona se è selezionato un dispositivo audio senza controllo nativo del volume.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "Brightness"; ObjectID = "uJS-s3-Zpi"; */
-"uJS-s3-Zpi.ibExternalAccessibilityDescription" = "Brightness";
+"uJS-s3-Zpi.ibExternalAccessibilityDescription" = "Luminosità";
 
 /* Class = "NSButtonCell"; title = "Enable keyboard control for display"; ObjectID = "UqR-WE-jHl"; */
-"UqR-WE-jHl.title" = "Controlla monitor da tastiera";
+"UqR-WE-jHl.title" = "Abilita il controllo da tastiera";
 
 /* Class = "NSTextFieldCell"; title = "Contrast (DDC)"; ObjectID = "urd-Rh-aiL"; */
-"urd-Rh-aiL.title" = "Contrast";
+"urd-Rh-aiL.title" = "Contrasto (DDC)";
 
 /* Class = "NSButtonCell"; title = "Do not use alternative brightness keys"; ObjectID = "vd2-Lk-neX"; */
-"vd2-Lk-neX.title" = "Do not use alternative brightness keys";
+"vd2-Lk-neX.title" = "Non utilizzare i tasti luminosità alternativi";
 
 /* Class = "NSMenuItem"; title = "Heavy"; ObjectID = "vik-vN-bJe"; */
-"vik-vN-bJe.title" = "Intensiva";
+"vik-vN-bJe.title" = "Pesante";
 
 /* Class = "NSTextFieldCell"; title = "Multiple displays:"; ObjectID = "vri-pv-tJ4"; */
-"vri-pv-tJ4.title" = "Multiple displays:";
+"vri-pv-tJ4.title" = "Monitor multipli:";
 
 /* Class = "NSTextFieldCell"; title = "DDC read polling mode:"; ObjectID = "vwm-hY-on5"; */
 "vwm-hY-on5.title" = "Modalità lettura polling DDC:";
 
 /* Class = "NSTextFieldCell"; title = "General options:"; ObjectID = "W58-ch-j69"; */
-"W58-ch-j69.title" = "General options:";
+"W58-ch-j69.title" = "Opzioni generali:";
 
 /* Class = "NSTextFieldCell"; title = "Useful when a display tends to reset its settings during sleep."; ObjectID = "w8B-x6-sq5"; */
-"w8B-x6-sq5.title" = "Useful when a display tends to reset its settings during sleep.";
+"w8B-x6-sq5.title" = "Utile se il monitor tende a resettare le impostazioni durante lo stop (sleep).";
 
 /* Class = "NSTextFieldCell"; title = "Changes that are caused by the Ambient light sensor or made using Touch Bar, Control Center, System Preferences will be replicated to all displays."; ObjectID = "wjv-tq-iUx"; */
-"wjv-tq-iUx.title" = "Changes that are caused by the Ambient light sensor or made using Touch Bar, Control Center, System Preferences will be replicated to all displays.";
+"wjv-tq-iUx.title" = "Le modifiche provocate dal sensore di luce ambiente o fatte attraverso la Touch Bar, Centro di Controllo, Preferenze di Sistema verranno replicate su tutti i monitor.";
 
 /* Class = "NSTextFieldCell"; title = "Display advanced settings and additional information in Preferences."; ObjectID = "X6w-Ee-9Jq"; */
-"X6w-Ee-9Jq.title" = "Display advanced settings and additional information in Preferences.";
+"X6w-Ee-9Jq.title" = "Mostra le impostazioni avanzate e le informazioni aggiuntive.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "Brightness"; ObjectID = "xDF-IA-bBh"; */
-"xDF-IA-bBh.ibExternalAccessibilityDescription" = "Brightness";
+"xDF-IA-bBh.ibExternalAccessibilityDescription" = "Luminosità";
 
 /* Class = "NSTextFieldCell"; title = "Update settings from the display. May not work with some hardware."; ObjectID = "xjq-hs-wWB"; */
-"xjq-hs-wWB.title" = "Update settings from the display. May not work with some hardware.";
+"xjq-hs-wWB.title" = "Aggiorna le impostazioni leggendole dal monitor. Potrebbe non funzionare con alcuni hardware.";
 
 /* Class = "NSMenuItem"; title = "Only if at least one slider is present"; ObjectID = "xLa-PN-rsq"; */
-"xLa-PN-rsq.title" = "Only if at least one slider is present";
+"xLa-PN-rsq.title" = "Solo e è presente almeno uno slider";
 
 /* Class = "NSMenuItem"; title = "Both standard and custom shortcuts"; ObjectID = "xQJ-aJ-VhH"; */
-"xQJ-aJ-VhH.title" = "Both standard and custom shortcuts";
+"xQJ-aJ-VhH.title" = "Entrambe le abbreviazioni standard e personalizzate";
 
 /* Class = "NSTextFieldCell"; title = "Works best with various syncing and 'control all' keyboard settings enabled."; ObjectID = "XU4-Bn-bwH"; */
-"XU4-Bn-bwH.title" = "Works best with various syncing and 'control all' keyboard settings enabled.";
+"XU4-Bn-bwH.title" = "Funziona se l'opzione 'controlla tutto' dalla tastiera è attivata.";
 
 /* Class = "NSTextFieldCell"; title = "Available"; ObjectID = "yBJ-5d-I7e"; */
-"yBJ-5d-I7e.title" = "Available";
+"yBJ-5d-I7e.title" = "Disponibile";
 
 /* Class = "NSTextFieldCell"; title = "Full OSD scale will be available for hardware brightness control and after reaching 0 brightness, further software dimming will be used."; ObjectID = "YHZ-VL-QJ3"; */
-"YHZ-VL-QJ3.title" = "Full OSD scale will be available for hardware brightness control and after reaching 0 brightness, further software dimming will be used.";
+"YHZ-VL-QJ3.title" = "L'intera scala OSD sarà disponibile per il controllo hardware della luminosità e una volta raggiunto lo 0, l'attenuazione software verrà utilizata.";
 
 /* Class = "NSButtonCell"; title = "Assume last saved settings are valid (recommended)"; ObjectID = "yn8-Nd-o89"; */
-"yn8-Nd-o89.title" = "Assume last saved settings are valid (recommended)";
+"yn8-Nd-o89.title" = "Assumi che le ultime impostazioni siano valide (raccomandato)";
 
 /* Class = "NSTextFieldCell"; title = "Decrease:"; ObjectID = "yQh-Ve-WEE"; */
-"yQh-Ve-WEE.title" = "Decrease:";
+"yQh-Ve-WEE.title" = "Diminiusci:";
 
 /* Class = "NSTextFieldCell"; title = "Identifier:"; ObjectID = "YqZ-LS-YvR"; */
-"YqZ-LS-YvR.title" = "Identificatore:";
+"YqZ-LS-YvR.title" = "Identificativo:";
 
 /* Class = "NSButtonCell"; title = "Use hardware DDC control"; ObjectID = "ZdU-gV-V05"; */
-"ZdU-gV-V05.title" = "Usa controllo hardware DDC";
+"ZdU-gV-V05.title" = "Utilizza controllo hardware DDC";
 
 /* Class = "NSMenuItem"; title = "Disable keyboard"; ObjectID = "zHa-xo-XPW"; */
-"zHa-xo-XPW.title" = "Disable keyboard";
+"zHa-xo-XPW.title" = "Disabilita tastiera";
 
 /* Class = "NSButtonCell"; title = "Donate"; ObjectID = "ZKk-ve-rS4"; */
 "ZKk-ve-rS4.title" = "Fai una donazione";
 
 /* Class = "NSButtonCell"; title = "Show percentages"; ObjectID = "ZUu-MR-XwA"; */
-"ZUu-MR-XwA.title" = "Show percentages";
+"ZUu-MR-XwA.title" = "Mostra la percentuale";
 
 /* Class = "NSTextFieldCell"; title = "Combined dimming switchover point:"; ObjectID = "zv8-pZ-OPy"; */
-"zv8-pZ-OPy.title" = "Combined dimming switchover point:";
+"zv8-pZ-OPy.title" = "Punto combinato di commutazione:";

--- a/MonitorControl/UI/ja.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/ja.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/ja.lproj/Localizable.strings
+++ b/MonitorControl/UI/ja.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "ショートカットキーを使用できません";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/ja.lproj/Main.strings
+++ b/MonitorControl/UI/ja.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Display type:";

--- a/MonitorControl/UI/ko.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/ko.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/ko.lproj/Localizable.strings
+++ b/MonitorControl/UI/ko.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "단축키를 사용할 수 없음";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "소프트웨어 (감마)";
+"Software (gamma)" = "소프트웨어 (감마)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "소프트웨어 (감마, 강제 적용)";
+"Software (gamma, forced)" = "소프트웨어 (감마, 강제 적용)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "소프트웨어 (명암)";
+"Software (shade)" = "소프트웨어 (명암)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "이 디스플레이는 하드웨어 제어를 지원하지 않기 때문에 감마 설정을 통해 소프트웨어로 밝기를 제어합니다. 그 이유는 하드웨어 DDC 제어가 차단된 Mac mini의 HDMI 포트를 사용하였거나 블랙리스트에 포함된 디스플레이를 사용하고 있기 때문일 수 있습니다.";

--- a/MonitorControl/UI/ko.lproj/Main.strings
+++ b/MonitorControl/UI/ko.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "단축키 기록:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "밝기 및 대비 제어:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/UI/nl.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/nl.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "Met MonitorControl kunt u de helderheid en het volume van externe beeldschermen regelen";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl controleert op nieuwe versies en beveiligingsupdates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "Als u deze verbindingen weigert, wordt u niet op de hoogte gebracht van nieuwe versies en beveiligingsupdates. Beveiligingsupdates zijn belangrijk ter bescherming tegen malware-aanvallen.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl controleert op nieuwe versies en beveiligingsupdates.";

--- a/MonitorControl/UI/nl.lproj/Localizable.strings
+++ b/MonitorControl/UI/nl.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Sneltoetsen niet beschikbaar";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Gedwongen)";
+"Software (gamma, forced)" = "Software (Gamma, Gedwongen)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Dit scherm maakt softwarematige helderheidsregeling via gammatable-manipulatie mogelijk, aangezien het geen hardwarecontrole ondersteunt. Redenen hiervoor kunnen het gebruik van de HDMI-poort van een Mac mini zijn (die hardwarematige DDC-besturing blokkeert) of een niet-ondersteund beeldscherm.";

--- a/MonitorControl/UI/nl.lproj/Main.strings
+++ b/MonitorControl/UI/nl.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Snelkoppelingen opnemen:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "Helderheid en contrastregeling:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/UI/pl.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/pl.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/pl.lproj/Localizable.strings
+++ b/MonitorControl/UI/pl.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Skróty klawiszowe niedostępne";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/pl.lproj/Main.strings
+++ b/MonitorControl/UI/pl.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Rodzaj wyświetlacza:";

--- a/MonitorControl/UI/ru.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/ru.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/ru.lproj/Localizable.strings
+++ b/MonitorControl/UI/ru.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Сочетания клавиш недоступны";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/ru.lproj/Main.strings
+++ b/MonitorControl/UI/ru.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Тип дисплея:";

--- a/MonitorControl/UI/tr.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/tr.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/tr.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/tr.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl, harici ekranların parlaklığını ve ses seviyesini kontrol etmenizi sağlar";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl, yeni sürümleri ve güvenlik güncellemelerini kontrol eder.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "Güvenlik güncellemelerini kontrol etmeyi reddederseniz, yeni sürümler ve güvenlik güncellemeleri hakkında bilgilendirilmeyeceksiniz. Kötü amaçlı yazılım saldırılarına karşı savunmak için güvenlik güncellemeleri önemlidir.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl, yeni sürümleri ve güvenlik güncellemelerini kontrol eder.";

--- a/MonitorControl/UI/tr.lproj/Localizable.strings
+++ b/MonitorControl/UI/tr.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Kısayollar bulunamadı";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/tr.lproj/Localizable.strings
+++ b/MonitorControl/UI/tr.lproj/Localizable.strings
@@ -92,10 +92,10 @@
 "Software (gamma)" = "Yazılım (Gama)";
 
 /* Shown in the Display Preferences */
-"Software (gamma, Forced)" = "Yazılım (Gama, Zorunlu)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Yazılım (Gölge)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "Bu ekran, donanım kontrolünü desteklemediği için gamlanabilir manipülasyon yoluyla yazılım parlaklık kontrolüne izin verir. Bunun nedenleri, bir Mac mini'nin (donanım DDC kontrolünü engelleyen) HDMI bağlantı noktasını kullanmak veya kara listeye alınmış bir ekrana sahip olmak olabilir.";

--- a/MonitorControl/UI/tr.lproj/Main.strings
+++ b/MonitorControl/UI/tr.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Ekran tipi:";

--- a/MonitorControl/UI/uk.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/uk.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/uk.lproj/Localizable.strings
+++ b/MonitorControl/UI/uk.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "Скорочення недоступні";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/uk.lproj/Main.strings
+++ b/MonitorControl/UI/uk.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "Display type:";

--- a/MonitorControl/UI/zh-Hans.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";

--- a/MonitorControl/UI/zh-Hans.lproj/Localizable.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "快捷键不可用";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "Software (Gamma)";
+"Software (gamma)" = "Software (gamma)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "Software (Gamma, Forced)";
+"Software (gamma, forced)" = "Software (gamma, forced)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "Software (Shade)";
+"Software (shade)" = "Software (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.";

--- a/MonitorControl/UI/zh-Hans.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/Main.strings
@@ -211,8 +211,8 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "Record shortcuts:";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
-"LO4-4k-gxY.title" = "Brightness and contrast control:";
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
+"LO4-4k-gxY.title" = "Brightness and contrast:";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */
 "lSJ-6w-KJ2.title" = "显示类型:";

--- a/MonitorControl/UI/zh-Hant-TW.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
 "ApplicationDescription" = "MonitorControl讓您可以控制外接螢幕的亮度與音量";
 
-/* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl會檢查新版本以及安全性更新。";
-
 /* Sofware update deny consequences */
 "SoftwareUpdateDenyConsequences" = "若您拒絕這些連線，您將不會收到新版本以及安全性更新的通知。 安全性更新對於抵禦惡意軟體的攻擊是相當重要的。";
+
+/* Software update purpose */
+"SoftwareUpdatePurpose" = "MonitorControl會檢查新版本以及安全性更新。";

--- a/MonitorControl/UI/zh-Hant-TW.lproj/InternetAccessPolicy.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/InternetAccessPolicy.strings
@@ -1,8 +1,8 @@
 /* General application description */
-"ApplicationDescription" = "MonitorControl allows you to control external displays brightness and volume";
+"ApplicationDescription" = "MonitorControl讓您可以控制外接螢幕的亮度與音量";
 
 /* Software update purpose */
-"SoftwareUpdatePurpose" = "MonitorControl checks for new versions and security updates.";
+"SoftwareUpdatePurpose" = "MonitorControl會檢查新版本以及安全性更新。";
 
 /* Sofware update deny consequences */
-"SoftwareUpdateDenyConsequences" = "If you deny these connections, you will not be notified about new versions and security updates. Security updates are important in order to defend against malware attacks.";
+"SoftwareUpdateDenyConsequences" = "若您拒絕這些連線，您將不會收到新版本以及安全性更新的通知。 安全性更新對於抵禦惡意軟體的攻擊是相當重要的。";

--- a/MonitorControl/UI/zh-Hant-TW.lproj/Localizable.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "Shortcuts not available" = "快捷鍵不可使用";
 
 /* Shown in the Display Preferences */
-"Software (Gamma)" = "軟體 (伽瑪)";
+"Software (gamma)" = "軟體 (伽瑪)";
 
 /* Shown in the Display Preferences */
-"Software (Gamma, Forced)" = "軟體 (伽瑪，強制)";
+"Software (gamma, forced)" = "軟體 (伽瑪，強制)";
 
 /* Shown in the Display Preferences */
-"Software (Shade)" = "軟體 (Shade)";
+"Software (shade)" = "軟體 (shade)";
 
 /* Shown in the Display Preferences */
 "This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display." = "此螢幕不支援硬體控制，亮度調整將以軟體調整伽瑪值來實現。原因可能出於使用Mac mini的HDMI埠（硬體DDC無法使用）或是使用不支援的螢幕。";

--- a/MonitorControl/UI/zh-Hant-TW.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/Main.strings
@@ -211,7 +211,7 @@
 /* Class = "NSTextFieldCell"; title = "Record shortcuts:"; ObjectID = "kqJ-jQ-b7U"; */
 "kqJ-jQ-b7U.title" = "記錄快捷鍵：";
 
-/* Class = "NSTextFieldCell"; title = "Brightness and contrast control:"; ObjectID = "LO4-4k-gxY"; */
+/* Class = "NSTextFieldCell"; title = "Brightness and contrast:"; ObjectID = "LO4-4k-gxY"; */
 "LO4-4k-gxY.title" = "亮度及對比度控制：";
 
 /* Class = "NSTextFieldCell"; title = "Display type:"; ObjectID = "lSJ-6w-KJ2"; */

--- a/MonitorControl/View Controllers/DisplaysPrefsViewController.swift
+++ b/MonitorControl/View Controllers/DisplaysPrefsViewController.swift
@@ -76,19 +76,19 @@ class DisplaysPrefsViewController: NSViewController, PreferencePane, NSTableView
     if display.isVirtual {
       displayType = NSLocalizedString("Virtual Display", comment: "Shown in the Display Preferences")
       displayImage = "tv.and.mediabox"
-      controlMethod = NSLocalizedString("Software (Shade)", comment: "Shown in the Display Preferences") + "  ⚠️"
+      controlMethod = NSLocalizedString("Software (shade)", comment: "Shown in the Display Preferences") + "  ⚠️"
       controlStatus = NSLocalizedString("This is a virtual display (examples: AirPlay, Sidecar, display connected via a DisplayLink Dock or similar) which does not allow hardware or software gammatable control. Shading is used as a substitute but only in non-mirror scenarios. Mouse cursor will be unaffected and artifacts may appear when entering/leaving full screen mode.", comment: "Shown in the Display Preferences")
     } else if display is OtherDisplay {
       displayType = NSLocalizedString("External Display", comment: "Shown in the Display Preferences")
       displayImage = "display"
       if let otherDisplay: OtherDisplay = display as? OtherDisplay {
         if otherDisplay.isSwOnly() {
-          controlMethod = NSLocalizedString("Software (Gamma)", comment: "Shown in the Display Preferences") + "  ⚠️"
+          controlMethod = NSLocalizedString("Software (gamma)", comment: "Shown in the Display Preferences") + "  ⚠️"
           displayImage = "display.trianglebadge.exclamationmark"
           controlStatus = NSLocalizedString("This display allows for software brightness control via gammatable manipulation as it does not support hardware control. Reasons for this might be using the HDMI port of a Mac mini (which blocks hardware DDC control) or having a blacklisted display.", comment: "Shown in the Display Preferences")
         } else {
           if otherDisplay.isSw() {
-            controlMethod = NSLocalizedString("Software (Gamma, Forced)", comment: "Shown in the Display Preferences") + "  ⚠️"
+            controlMethod = NSLocalizedString("Software (gamma, forced)", comment: "Shown in the Display Preferences") + "  ⚠️"
             controlStatus = NSLocalizedString("This display is reported to support hardware DDC control but the current settings allow for software control only.", comment: "Shown in the Display Preferences")
           } else {
             controlMethod = NSLocalizedString("Hardware (DDC)", comment: "Shown in the Display Preferences")

--- a/MonitorControl/View Controllers/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/KeyboardPrefsViewController.swift
@@ -52,6 +52,7 @@ class KeyboardPrefsViewController: NSViewController, PreferencePane {
   @IBOutlet var rowSeparateCombinedScaleCheck: NSGridRow!
   @IBOutlet var rowSeparateCombinedScaleText: NSGridRow!
 
+  // swiftlint:disable cyclomatic_complexity
   func showAdvanced() -> Bool {
     let hide = !prefs.bool(forKey: PrefKey.showAdvancedSettings.rawValue)
 
@@ -152,6 +153,8 @@ class KeyboardPrefsViewController: NSViewController, PreferencePane {
 
     return !hide
   }
+
+  // swiftlint:enable cyclomatic_complexity
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/MonitorControl/View Controllers/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/KeyboardPrefsViewController.swift
@@ -91,10 +91,32 @@ class KeyboardPrefsViewController: NSViewController, PreferencePane {
       self.rowCustomBrightnessShortcuts.isHidden = true
     }
 
+    if self.keyboardBrightness.selectedTag() == KeyboardBrightness.disabled.rawValue {
+      self.allScreens.isEnabled = false
+      self.useFocusInsteadOfMouse.isEnabled = false
+      self.useFineScale.isEnabled = false
+      self.separateCombinedScale.isEnabled = false
+    } else {
+      self.allScreens.isEnabled = true
+      self.useFocusInsteadOfMouse.isEnabled = self.allScreens.state == .off ? true : false
+      self.useFineScale.isEnabled = true
+      self.separateCombinedScale.isEnabled = true
+    }
+
     if [KeyboardVolume.custom.rawValue, KeyboardVolume.both.rawValue].contains(self.keyboardVolume.selectedTag()) {
       self.rowCustomAudioShortcuts.isHidden = false
     } else {
       self.rowCustomAudioShortcuts.isHidden = true
+    }
+
+    if self.keyboardVolume.selectedTag() == KeyboardVolume.disabled.rawValue {
+      self.allScreensVolume.isEnabled = false
+      self.useAudioDeviceNameMatching.isEnabled = false
+      self.useFineScaleVolume.isEnabled = false
+    } else {
+      self.allScreensVolume.isEnabled = true
+      self.useAudioDeviceNameMatching.isEnabled = self.allScreensVolume.state == .off ? true : false
+      self.useFineScaleVolume.isEnabled = true
     }
 
     if self.useFocusInsteadOfMouse.state == .on {

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6350</string>
+	<string>6359</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6389</string>
+	<string>6390</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6307</string>
+	<string>6314</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6370</string>
+	<string>6389</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6359</string>
+	<string>6370</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6322</string>
+	<string>6350</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6314</string>
+	<string>6322</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
- Fixes clipping English text when gamma control is forced.
- Fixes clipping view in Displays with Chinese text.
- Set relevant options to disabled when keyboard control is disabled.
- Added Command+Q shortcut in menu when it is in standard text mode (not icon mode).
- Gearshape icon is used for preferences + stands a little bit apart to help user focus.
- Make preferences more spacious + more room for verbose languages
- Fixed dutch version clipping issues
- Added beta channel update backend