### PR TITLE
Add ⌘ + , keyboard shortcut to "Preferences..."

### DIFF
--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -266,7 +266,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       if app.macOS10() {
         self.insertItem(NSMenuItem.separator(), at: self.items.count)
       }
-      self.insertItem(withTitle: NSLocalizedString("Preferences…", comment: "Shown in menu"), action: #selector(app.prefsClicked), keyEquivalent: "", at: self.items.count)
+      self.insertItem(withTitle: NSLocalizedString("Preferences…", comment: "Shown in menu"), action: #selector(app.prefsClicked), keyEquivalent: ",", at: self.items.count)
       let updateItem = NSMenuItem(title: NSLocalizedString("Check for updates…", comment: "Shown in menu"), action: #selector(app.updaterController.checkForUpdates(_:)), keyEquivalent: "")
       updateItem.target = app.updaterController
       self.insertItem(updateItem, at: self.items.count)


### PR DESCRIPTION
## Changes
- Add `⌘ + w` key equivalent to "Preferences..."
  - Now it's easier to open Preferences Panel with keyboard shortcut

### Before
![image](https://user-images.githubusercontent.com/12025248/139583085-31679ad3-8a62-4bfa-986a-0d32c7752607.png)

### After
![image](https://user-images.githubusercontent.com/12025248/139583088-fd3f50ff-55bb-44a1-90c2-e9c1a403cb7b.png)
