### PR TITLE
Fixed Samsung 28E850 being treated as a dummy.

### DIFF
--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6956</string>
+	<string>6957</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -313,7 +313,11 @@ class DisplayManager {
           os_log("Display service match successful for display %{public}@", type: .info, String(serviceMatch.displayID))
           if serviceMatch.isDiscouraged {
             os_log("Display %{public}@ is flagged as discouraged by Arm64DDC.", type: .info, String(serviceMatch.displayID))
-            otherDisplay.isDiscouraged = serviceMatch.isDiscouraged
+            otherDisplay.isDiscouraged = true
+          } else if serviceMatch.isDummy {
+            os_log("Display %{public}@ is flagged as dummy by Arm64DDC.", type: .info, String(serviceMatch.displayID))
+            otherDisplay.isDiscouraged = true
+            otherDisplay.isDummy = true
           } else {
             otherDisplay.arm64ddc = DEBUG_SW ? false : true // MARK: (point of interest when testing)
           }
@@ -396,7 +400,7 @@ class DisplayManager {
   static func isDummy(displayID: CGDirectDisplayID) -> Bool {
     let rawName = DisplayManager.getDisplayRawNameByID(displayID: displayID)
     var isDummy: Bool = false
-    if rawName == "28E850" || rawName.lowercased().contains("dummy") {
+    if rawName.lowercased().contains("dummy") {
       os_log("NOTE: Display is a dummy!", type: .info)
       isDummy = true
     }

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6956</string>
+	<string>6957</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/README.md
+++ b/README.md
@@ -99,11 +99,7 @@ _* With some limitations - full functionality available on macOS 11 Big Sur or n
 - LCD and LED Televisions usually do not implement DDC, these are supported using software alternatives to dim the image (some higher-end sets are able to translate this into hardware backlight dimming).
 - OLED or mini/micro-LED displays and televisions are fully supported using gamma table manipulation (this is a no-compromise solution for this class of displays).
 - DisplayLink, Airplay and Sidecar are supported using shade (dark overlay) control.
-
-Dummy compatibility:
-
 - The app is compatible with [BetterDummy](https://github.com/waydabber/BetterDummy) mirrored sets.
-- The app is compatible with mirrored sets that include a dummy dongle identifying as `28E850`
 
 Notable exceptions for hardware control compatibility:
 


### PR DESCRIPTION
Due to a problem in identification the really existing Samsung 28E850 display was treated as a dummy (most dummies identify themselves as AOC 28E850).