### PR TITLE
Fix SimplyCoreAudio incompatibility

### DIFF
--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -939,8 +939,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/rnine/SimplyCoreAudio";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.1;
+				kind = revision;
+				revision = 75970285e2470f12a569cdff68ef5a75498a4646;
 			};
 		};
 		6CD35F5426500008001F1344 /* XCRemoteSwiftPackageReference "MediaKeyTap" */ = {

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6965</string>
+	<string>6968</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Support/AppDelegate.swift
+++ b/MonitorControl/Support/AppDelegate.swift
@@ -284,7 +284,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   @objc func audioDeviceChanged() {
     if let defaultDevice = self.coreAudio.defaultOutputDevice {
       os_log("Default output device changed to “%{public}@”.", type: .info, defaultDevice.name)
-      os_log("Can device set its own volume? %{public}@", type: .info, defaultDevice.canSetVirtualMasterVolume(scope: .output).description)
+      os_log("Can device set its own volume? %{public}@", type: .info, defaultDevice.canSetVirtualMainVolume(scope: .output).description)
     }
     self.updateMediaKeyTap()
   }

--- a/MonitorControl/Support/MediaKeyTapManager.swift
+++ b/MonitorControl/Support/MediaKeyTapManager.swift
@@ -173,7 +173,7 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
         if DisplayManager.shared.updateAudioControlTargetDisplays(deviceName: defaultAudioDevice.name) == 0 {
           keys.removeAll { keysToDelete.contains($0) }
         }
-      } else if defaultAudioDevice.canSetVirtualMasterVolume(scope: .output) == true {
+      } else if defaultAudioDevice.canSetVirtualMainVolume(scope: .output) == true {
         keys.removeAll { keysToDelete.contains($0) }
       }
     }

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>6965</string>
+	<string>6968</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
SimplyCoreAudio 4.0.1 is incompatible with XCode 13 therefore MonitorControl build fails. There is no newer tag than 4.0.1 at rnine/SimplyCoreAudio but the issue was fixed in the develop branch back when I reported the problem in that repo.

I did the following:

- Updated the package dependency to SimplyCoreAudio commit [75970285e2470f12a569cdff68ef5a75498a4646](https://github.com/rnine/SimplyCoreAudio/commit/75970285e2470f12a569cdff68ef5a75498a4646) -> this can be revised when a new tag is available at rnine/SimplyCoreAudio.
- Renamed deprecated `canSetVirtualMasterVolume` to `canSetVirtualMainVolume` calls in MonitorControl.