### PR TITLE
Add check for M1 Pro/Max Macbook Pro HDMI

### DIFF
--- a/MonitorControl/Support/Arm64DDC.swift
+++ b/MonitorControl/Support/Arm64DDC.swift
@@ -278,8 +278,13 @@ class Arm64DDC: NSObject {
     if let modelData = IORegistryEntryCreateCFProperty(platformExpertDevice, "model" as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? Data, let modelIdentifierCString = String(data: modelData, encoding: .utf8)?.cString(using: .utf8) {
       modelIdentifier = String(cString: modelIdentifierCString)
     }
-    // First service location of Mac Mini HDMI is broken for DDC communication
-    if ioregService.transportDownstream == "HDMI", ioregService.serviceLocation == 1, modelIdentifier == "Macmini9,1" {
+    // First service location of M1 Mac Mini & Macbook Pro HDMI is broken for DDC communication
+    let ddcBlockedModels = [
+      "Macmini9", // Mac mini M1 2020
+      "MacBookPro18", // Macbook Pro M1 Pro/Max 2021 (14", 16")
+    ]
+    let isBlockedModel = ddcBlockedModels.contains { $0.starts(with: modelIdentifier) }
+    if ioregService.transportDownstream == "HDMI", ioregService.serviceLocation == 1, isBlockedModel {
       return true
     }
     return false


### PR DESCRIPTION
As with the Mac mini, the new Macbook Pro (M1 Pro/Max, 14" and 16") models of 2021 seems to have DDC communication blocked on their HDMI port.

This PR add a check for these models. (And an easy way to add newer models if needed)