### PR TITLE
Support show icon when has an external monitor

### DIFF
--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -190,7 +190,8 @@ enum PollingMode: Int {
 enum MenuIcon: Int {
   case show = 0
   case sliderOnly = 1
-  case hide = 2
+  case externalMonitorOnly = 2
+  case hide = 3
 }
 
 enum MenuItemStyle: Int {

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7028</string>
+	<string>7029</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -183,6 +183,19 @@ class MenuHandler: NSMenu, NSMenuDelegate {
     if addedSliderHandlers.count > 0, prefs.integer(forKey: PrefKey.menuIcon.rawValue) == MenuIcon.sliderOnly.rawValue {
       app.statusItem.isVisible = true
     }
+    if prefs.integer(forKey: PrefKey.menuIcon.rawValue) == MenuIcon.externalMonitorOnly.rawValue {
+      var hasExternalMonitor = false
+      for slider in addedSliderHandlers {
+        for dis in slider.displays where dis is MonitorControl.OtherDisplay {
+          hasExternalMonitor = true
+          break
+        }
+        if hasExternalMonitor {
+          app.statusItem.isVisible = true;
+          break
+        }
+      }
+    }
   }
 
   private func appendMenuHeader(friendlyName: String, monitorSubMenu: NSMenu, asSubMenu: Bool, numOfDisplays: Int) {

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -368,6 +368,7 @@
                                                     <items>
                                                         <menuItem title="Always show in the menu bar" state="on" id="MM0-Lf-VgF"/>
                                                         <menuItem title="Only if at least one slider is present" tag="1" id="xLa-PN-rsq"/>
+                                                        <menuItem title="Only if has an external monitor" tag="2" id="nZH-ma-he4"/>
                                                         <menuItem title="Always hide" tag="2" id="6mo-7S-oOO"/>
                                                     </items>
                                                 </menu>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7028</string>
+	<string>7029</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
Since the new Macbook Pro 14 inches has a notch, the menu bar space is limited, I only want menu icons to show when plugging an external monitor, when I unplugged it, the icon should be hidden, so it will save menu bar space.

So I introduced a new menu Icon option: Only if has an external monitor.