### PR TITLE
Improved dummy detection for newer versions of BetterDummy

### DIFF
--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7029</string>
+	<string>7030</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -399,13 +399,13 @@ class DisplayManager {
   }
 
   static func isDummy(displayID: CGDirectDisplayID) -> Bool {
+    let vendorNumber = CGDisplayVendorNumber(displayID)
     let rawName = DisplayManager.getDisplayRawNameByID(displayID: displayID)
-    var isDummy: Bool = false
-    if rawName.lowercased().contains("dummy") {
+    if rawName.lowercased().contains("dummy") || (self.isVirtual(displayID: displayID) && vendorNumber == UInt32(0xF0F0)) {
       os_log("NOTE: Display is a dummy!", type: .info)
-      isDummy = true
+      return true
     }
-    return isDummy
+    return false
   }
 
   static func isVirtual(displayID: CGDirectDisplayID) -> Bool {

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7029</string>
+	<string>7030</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
BetterDummy v1.1.0 now allows renaming dummies which messes with the dummy detection of MonitorControl. This change fixes this issue.