### PR TITLE
Remove opening menu after onboarding

### DIFF
--- a/MonitorControl/View Controllers/Onboarding/OnboardingViewController.swift
+++ b/MonitorControl/View Controllers/Onboarding/OnboardingViewController.swift
@@ -22,9 +22,6 @@ class OnboardingViewController: NSViewController {
 
   @IBAction func closeButtonTouched(_: NSButton) {
     self.view.window?.close()
-    DispatchQueue.main.async {
-      app.statusItem.button?.performClick(self)
-    }
   }
 
   // MARK: - Style


### PR DESCRIPTION
This remove the opening of the menu after clicking on close on the onboarding because of a bug making the menu unusable.