### PR TITLE
Fix build scripts for m1 mac

### DIFF
--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -515,7 +515,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\" >&2\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftformat >/dev/null; then\n  swiftformat .\nelse\n  echo \"warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat\" >&2\nfi\n";
 		};
 		28F6A5802283515F00A4ADCD /* Increase Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -569,7 +569,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which bartycrouch > /dev/null; then\n    bartycrouch update -x\n    bartycrouch lint -x\nelse\n    echo \"warning: BartyCrouch not installed, download it from https://github.com/Flinesoft/BartyCrouch\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which bartycrouch > /dev/null; then\n    bartycrouch update -x\n    bartycrouch lint -x\nelse\n    echo \"warning: BartyCrouch not installed, download it from https://github.com/Flinesoft/BartyCrouch\"\nfi\n";
 		};
 		F03A8DF01FFB9D4C0034DC27 /* [Lint] Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -583,7 +583,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" >&2\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" >&2\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/MonitorControl/Support/Arm64DDC.swift
+++ b/MonitorControl/Support/Arm64DDC.swift
@@ -75,7 +75,7 @@ class Arm64DDC: NSObject {
 
   // Performs DDC read or write
   public static func performDDCCommunication(service: IOAVService?, send: inout [UInt8], reply: inout [UInt8], writeSleepTime: UInt32 = 10000, numofWriteCycles: UInt8 = 2, readSleepTime: UInt32 = 10000, numOfRetryAttemps: UInt8 = 3, retrySleepTime: UInt32 = 20000) -> Bool {
-    var success: Bool = false
+    var success = false
     guard service != nil else {
       return success
     }
@@ -133,8 +133,8 @@ class Arm64DDC: NSObject {
 
   // Scores the likelihood of a display match based on EDID UUID, ProductName and SerialNumber from in ioreg, compared to DisplayCreateInfoDictionary.
   private static func ioregMatchScore(displayID: CGDirectDisplayID, ioregEdidUUID: String, ioregProductName: String = "", ioregSerialNumber: Int64 = 0, serviceLocation: Int = 0) -> Int {
-    var matchScore: Int = 0
-    if let dictionary = (CoreDisplay_DisplayCreateInfoDictionary(displayID))?.takeRetainedValue() as NSDictionary? {
+    var matchScore = 0
+    if let dictionary = CoreDisplay_DisplayCreateInfoDictionary(displayID)?.takeRetainedValue() as NSDictionary? {
       if let kDisplayYearOfManufacture = dictionary[kDisplayYearOfManufacture] as? Int64, let kDisplayWeekOfManufacture = dictionary[kDisplayWeekOfManufacture] as? Int64, let kDisplayVendorID = dictionary[kDisplayVendorID] as? Int64, let kDisplayProductID = dictionary[kDisplayProductID] as? Int64, let kDisplayVerticalImageSize = dictionary[kDisplayVerticalImageSize] as? Int64, let kDisplayHorizontalImageSize = dictionary[kDisplayHorizontalImageSize] as? Int64 {
         struct KeyLoc {
           var key: String
@@ -172,7 +172,7 @@ class Arm64DDC: NSObject {
 
   // Iterate to the next AppleCLCD2 or DCPAVServiceProxy item in the ioreg tree and return the name and corresponding service
   private static func ioregIterateToNextObjectOfInterest(interests _: [String], iterator: inout io_iterator_t) -> (name: String, service: io_service_t)? {
-    var objectName: String = ""
+    var objectName = ""
     var service: io_service_t = IO_OBJECT_NULL
     let name = UnsafeMutablePointer<CChar>.allocate(capacity: MemoryLayout<io_name_t>.size)
     defer {
@@ -236,7 +236,7 @@ class Arm64DDC: NSObject {
 
   // Returns IOAVSerivces with associated display properties for matching logic
   private static func getIoregServicesForMatching() -> [IOregService] {
-    var serviceLocation: Int = 0
+    var serviceLocation = 0
     var ioregServicesForMatching: [IOregService] = []
     let ioregRoot: io_registry_entry_t = IORegistryGetRootEntry(kIOMasterPortDefault)
     var iterator = io_iterator_t()
@@ -273,7 +273,7 @@ class Arm64DDC: NSObject {
 
   // Check if it is problematic to enable DDC on the display
   private static func checkIfDiscouraged(ioregService: IOregService) -> Bool {
-    var modelIdentifier: String = ""
+    var modelIdentifier = ""
     let platformExpertDevice = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"))
     if let modelData = IORegistryEntryCreateCFProperty(platformExpertDevice, "model" as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? Data, let modelIdentifierCString = String(data: modelData, encoding: .utf8)?.cString(using: .utf8) {
       modelIdentifier = String(cString: modelIdentifierCString)

--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -220,7 +220,7 @@ class DisplayManager {
   func updateAudioControlTargetDisplays(deviceName: String) -> Int {
     self.audioControlTargetDisplays.removeAll()
     os_log("Detecting displays for audio control via audio device name matching...", type: .info)
-    var numOfAddedDisplays: Int = 0
+    var numOfAddedDisplays = 0
     for ddcCapableDisplay in self.getDdcCapableDisplays() {
       var displayAudioDeviceName = ddcCapableDisplay.readPrefAsString(key: .audioDeviceNameOverride)
       if displayAudioDeviceName == "" {
@@ -409,9 +409,9 @@ class DisplayManager {
   }
 
   static func isVirtual(displayID: CGDirectDisplayID) -> Bool {
-    var isVirtual: Bool = false
+    var isVirtual = false
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {
-      if let dictionary = ((CoreDisplay_DisplayCreateInfoDictionary(displayID))?.takeRetainedValue() as NSDictionary?) {
+      if let dictionary = (CoreDisplay_DisplayCreateInfoDictionary(displayID)?.takeRetainedValue() as NSDictionary?) {
         let isVirtualDevice = dictionary["kCGDisplayIsVirtualDevice"] as? Bool
         let displayIsAirplay = dictionary["kCGDisplayIsAirPlay"] as? Bool
         if isVirtualDevice ?? displayIsAirplay ?? false {
@@ -490,9 +490,9 @@ class DisplayManager {
   }
 
   static func getDisplayRawNameByID(displayID: CGDirectDisplayID) -> String {
-    let defaultName: String = ""
+    let defaultName = ""
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {
-      if let dictionary = ((CoreDisplay_DisplayCreateInfoDictionary(displayID))?.takeRetainedValue() as NSDictionary?), let nameList = dictionary["DisplayProductName"] as? [String: String], let name = nameList["en_US"] ?? nameList.first?.value {
+      if let dictionary = (CoreDisplay_DisplayCreateInfoDictionary(displayID)?.takeRetainedValue() as NSDictionary?), let nameList = dictionary["DisplayProductName"] as? [String: String], let name = nameList["en_US"] ?? nameList.first?.value {
         return name
       }
     }
@@ -505,10 +505,10 @@ class DisplayManager {
   static func getDisplayNameByID(displayID: CGDirectDisplayID) -> String {
     let defaultName: String = NSLocalizedString("Unknown", comment: "Unknown display name")
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {
-      if let dictionary = ((CoreDisplay_DisplayCreateInfoDictionary(displayID))?.takeRetainedValue() as NSDictionary?), let nameList = dictionary["DisplayProductName"] as? [String: String], var name = nameList[Locale.current.identifier] ?? nameList["en_US"] ?? nameList.first?.value {
+      if let dictionary = (CoreDisplay_DisplayCreateInfoDictionary(displayID)?.takeRetainedValue() as NSDictionary?), let nameList = dictionary["DisplayProductName"] as? [String: String], var name = nameList[Locale.current.identifier] ?? nameList["en_US"] ?? nameList.first?.value {
         if CGDisplayIsInHWMirrorSet(displayID) != 0 || CGDisplayIsInMirrorSet(displayID) != 0 {
           let mirroredDisplayID = CGDisplayMirrorsDisplay(displayID)
-          if mirroredDisplayID != 0, let dictionary = ((CoreDisplay_DisplayCreateInfoDictionary(mirroredDisplayID))?.takeRetainedValue() as NSDictionary?), let nameList = dictionary["DisplayProductName"] as? [String: String], let mirroredName = nameList[Locale.current.identifier] ?? nameList["en_US"] ?? nameList.first?.value {
+          if mirroredDisplayID != 0, let dictionary = (CoreDisplay_DisplayCreateInfoDictionary(mirroredDisplayID)?.takeRetainedValue() as NSDictionary?), let nameList = dictionary["DisplayProductName"] as? [String: String], let mirroredName = nameList[Locale.current.identifier] ?? nameList["en_US"] ?? nameList.first?.value {
             name.append(" | " + mirroredName)
           }
         }

--- a/MonitorControl/Support/IntelDDC.swift
+++ b/MonitorControl/Support/IntelDDC.swift
@@ -32,7 +32,7 @@ public class IntelDDC {
   }
 
   public func write(command: UInt8, value: UInt16, errorRecoveryWaitTime: UInt32? = nil, writeSleepTime: UInt32 = 10000, numofWriteCycles: UInt8 = 2) -> Bool {
-    var success: Bool = false
+    var success = false
     var data: [UInt8] = Array(repeating: 0, count: 7)
 
     data[0] = 0x51

--- a/MonitorControl/Support/KeyboardShortcutsManager.swift
+++ b/MonitorControl/Support/KeyboardShortcutsManager.swift
@@ -113,7 +113,7 @@ class KeyboardShortcutsManager {
       return
     }
     for display in affectedDisplays where !display.readPrefAsBool(key: .isDisabled) {
-      var isAnyDisplayInSwAfterBrightnessMode: Bool = false
+      var isAnyDisplayInSwAfterBrightnessMode = false
       for display in affectedDisplays where ((display as? OtherDisplay)?.isSwBrightnessNotDefault() ?? false) && !((display as? OtherDisplay)?.isSw() ?? false) && prefs.bool(forKey: PrefKey.separateCombinedScale.rawValue) {
         isAnyDisplayInSwAfterBrightnessMode = true
       }

--- a/MonitorControl/Support/MediaKeyTapManager.swift
+++ b/MonitorControl/Support/MediaKeyTapManager.swift
@@ -113,7 +113,7 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
         if isContrast, let otherDisplay = display as? OtherDisplay {
           otherDisplay.stepContrast(isUp: mediaKey == .brightnessUp, isSmallIncrement: isSmallIncrement)
         } else {
-          var isAnyDisplayInSwAfterBrightnessMode: Bool = false
+          var isAnyDisplayInSwAfterBrightnessMode = false
           for display in affectedDisplays where ((display as? OtherDisplay)?.isSwBrightnessNotDefault() ?? false) && !((display as? OtherDisplay)?.isSw() ?? false) && prefs.bool(forKey: PrefKey.separateCombinedScale.rawValue) {
             isAnyDisplayInSwAfterBrightnessMode = true
           }

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -222,7 +222,7 @@ class SliderHandler {
       slider.frame.origin = NSPoint(x: 15, y: 5)
       let view = NSView(frame: NSRect(x: 0, y: 0, width: slider.frame.width + 30 + (showPercent ? 38 : 0), height: slider.frame.height + 14))
       view.frame.origin = NSPoint(x: 12, y: 0)
-      var iconName: String = "circle.dashed"
+      var iconName = "circle.dashed"
       switch command {
       case .audioSpeakerVolume: iconName = "speaker.wave.2.fill"
       case .brightness: iconName = "sun.max.fill"
@@ -361,7 +361,7 @@ class SliderHandler {
       var sumVal: Float = 0
       var maxVal: Float = 0
       var minVal: Float = 1
-      var num: Int = 0
+      var num = 0
       for key in self.values.keys {
         if let val = values[key] {
           sumVal += val

--- a/MonitorControl/View Controllers/Preferences/DisplaysPrefsCellView.swift
+++ b/MonitorControl/View Controllers/Preferences/DisplaysPrefsCellView.swift
@@ -332,7 +332,7 @@ class DisplaysPrefsCellView: NSTableCellView {
     let value = sender.stringValue
     let values = value.components(separatedBy: ",")
     var normalizedValues: [String] = []
-    var normalizedString: String = ""
+    var normalizedString = ""
     for value in values {
       let trimmedValue = value.trimmingCharacters(in: CharacterSet(charactersIn: " "))
       if !trimmedValue.isEmpty, let intValue = UInt8(trimmedValue, radix: 16), intValue != 0 {

--- a/MonitorControl/main.swift
+++ b/MonitorControl/main.swift
@@ -28,7 +28,7 @@ let keyboardPrefsVc = storyboard.instantiateController(withIdentifier: "Keyboard
 let aboutPrefsVc = storyboard.instantiateController(withIdentifier: "AboutPrefsVC") as? AboutPrefsViewController
 let onboardingVc = storyboard.instantiateController(withIdentifier: "onboardingViewController") as? NSWindowController
 
-autoreleasepool { () -> Void in
+autoreleasepool { () in
   let mc = NSApplication.shared
   let mcDelegate = AppDelegate()
   mc.delegate = mcDelegate


### PR DESCRIPTION
I added `export PATH="$PATH:/opt/homebrew/bin"` to the build scripts (`swiftformat`, `bartycrouch` & `swiftlint`) for them to work on m1 macs (and homebrew).

I also pushed the automatic changes made by `swiftformat`.