### PR TITLE
Add GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 
+github: MonitorControl
 open_collective: monitorcontrol


### PR DESCRIPTION
This enable Github Sponsors for the repo so that people have the option to donate directly on the GitHub website.