### PR TITLE
fix: correct zh-TW translation in #1417

### DIFF
--- a/MonitorControl/UI/zh-Hant-TW.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/Main.strings
@@ -239,7 +239,7 @@
 "ltL-gR-K3Z.title" = "控制的螢幕：";
 
 /* Class = "NSTextFieldCell"; title = "Control your external displays brightness, contrast and volume directly from your Mac, using menulet sliders or the keyboard, including native Apple keys."; ObjectID = "Mh5-1A-apq"; */
-"Mh5-1A-apq.title" = "使用菜單上的滑桿或者鍵盤（支持Apple原生快捷鍵），直接從Mac控制外接螢幕的亮度、對比度和音量。";
+"Mh5-1A-apq.title" = "透過滑桿、鍵盤（含Apple原生快捷鍵），直接從Mac控制外接螢幕的亮度、對比度和音量。";
 
 /* Class = "NSButtonCell"; title = "Enable slider snapping"; ObjectID = "MlU-hl-d46"; */
 "MlU-hl-d46.title" = "啟用滑桿定位";


### PR DESCRIPTION
As spotted in the release 4.2.0, there is an incorrectly localized string in #1417. The PR corrects the issue.