### PR TITLE
Polish GHA using

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: xcodebuild
-        uses: sersoft-gmbh/xcodebuild-action@v1
+        uses: sersoft-gmbh/xcodebuild-action@v3
         with:
           project: MonitorControl.xcodeproj
           scheme: MonitorControl
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1


### PR DESCRIPTION
- Now move build to macos-latest which is based on arm64 on macOS 14.
- Bump actions to the latest, the old ones based on Node 16 are deprecated.