### PR TITLE
Add ability to command-drag out status item to remove

### DIFF
--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -33,7 +33,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
     if !dontClose {
       self.cancelTrackingWithoutAnimation()
     }
-    app.statusItem.isVisible = prefs.integer(forKey: PrefKey.menuIcon.rawValue) == MenuIcon.show.rawValue ? true : false
+    app.updateStatusItemVisibility(prefs.integer(forKey: PrefKey.menuIcon.rawValue) == MenuIcon.show.rawValue ? true : false)
     self.clearMenu()
     let currentDisplay = DisplayManager.shared.getCurrentDisplay()
     var displays: [Display] = []
@@ -185,7 +185,7 @@ class MenuHandler: NSMenu, NSMenuDelegate {
       self.addDisplayMenuBlock(addedSliderHandlers: addedSliderHandlers, blockName: display.readPrefAsString(key: .friendlyName) != "" ? display.readPrefAsString(key: .friendlyName) : display.name, monitorSubMenu: monitorSubMenu, numOfDisplays: numOfDisplays, asSubMenu: asSubMenu)
     }
     if addedSliderHandlers.count > 0, prefs.integer(forKey: PrefKey.menuIcon.rawValue) == MenuIcon.sliderOnly.rawValue {
-      app.statusItem.isVisible = true
+      app.updateStatusItemVisibility(true)
     }
   }
 

--- a/MonitorControl/View Controllers/Preferences/MenuslidersPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/MenuslidersPrefsViewController.swift
@@ -80,6 +80,7 @@ class MenuslidersPrefsViewController: NSViewController, SettingsPane {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.populateSettings()
+    prefs.addObserver(self, forKeyPath: PrefKey.menuIcon.rawValue, context: nil)
   }
 
   func populateSettings() {
@@ -209,5 +210,13 @@ class MenuslidersPrefsViewController: NSViewController, SettingsPane {
     }
     app.updateMenusAndKeys()
     self.updateGridLayout()
+  }
+  
+  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    guard let object = object as? AnyObject else { return }
+    if object === prefs, keyPath == PrefKey.menuIcon.rawValue {
+      self.populateSettings()
+      self.updateGridLayout()
+    }
   }
 }


### PR DESCRIPTION
A small change which adds the ability to command-drag the status item out of the menu bar to remove it, as a shortcut.

When this happens, the "Menu Icon" setting updates to "Always hide" automatically. With this behaviour, there were also some cases where that setting would get updated inadvertently from other changes to the status item's visibility. A `updateStatusItemVisibility` method was added to reliably detect whether the status item's visibility was due to the user dragging out the item, and not from something else.