### PR TITLE
Fix UI display issues and improve macOS Tahoe/Sequoia support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,15 @@ Carthage
 
 ### Xcode ###
 xcuserdata/
+*.xcuserstate
+*.xccheckout
+*.xcscmblueprint
+
+### Xcode / SwiftPM (local build outputs beside the project) ###
+.build/
+.derivedData/
+build/
+DerivedData/
+
+### SwiftPM — user-specific; keep Package.resolved tracked ###
+.swiftpm/xcode/xcuserdata/

--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		F06792F6200A745F0066C438 /* MonitorControlHelper.app in [Login] Copy Helper to start at Login */ = {isa = PBXBuildFile; fileRef = F06792E7200A73460066C438 /* MonitorControlHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F0A489C4279C71B200BEDFD6 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A489C3279C71B200BEDFD6 /* OnboardingViewController.swift */; };
 		FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E0895249D584C003A50BB /* OSDUtils.swift */; };
+		CE12345678901234003A50BB /* CustomHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12345678901234003A50BC /* CustomHUD.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -181,6 +182,7 @@
 		FB5DB28F2AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InternetAccessPolicy.strings"; sourceTree = "<group>"; };
 		FB5DB2902AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FE4E0895249D584C003A50BB /* OSDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDUtils.swift; sourceTree = "<group>"; };
+		CE12345678901234003A50BC /* CustomHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHUD.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -317,6 +319,7 @@
 				AA16139A26BE772E00DCF027 /* Arm64DDC.swift */,
 				AA4398A826DD55DA00943F16 /* IntelDDC.swift */,
 				FE4E0895249D584C003A50BB /* OSDUtils.swift */,
+				CE12345678901234003A50BC /* CustomHUD.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				AA062E8E26CA7BE5007E628C /* DisplaysPrefsCellView.swift in Sources */,
 				AA25F6D726E68C160087F3A2 /* MediaKeyTapManager.swift in Sources */,
 				FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */,
+				CE12345678901234003A50BB /* CustomHUD.swift in Sources */,
 				6CBFE27A23DB266000D1BC41 /* Display.swift in Sources */,
 				AA44E70727038F7F00E06865 /* KeyboardShortcutsManager.swift in Sources */,
 				F03A8DF21FFBAA6F0034DC27 /* OtherDisplay.swift in Sources */,

--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -212,4 +212,6 @@ enum KeyboardVolume: Int {
   case custom = 1
   case both = 2
   case disabled = 3
+  /// Like `media`, but always captures volume/mute keys even when macOS can control the default output device.
+  case mediaForce = 4
 }

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7141</string>
+	<string>7168</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7168</string>
+	<string>7171</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7176</string>
+	<string>7182</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7175</string>
+	<string>7176</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7171</string>
+	<string>7175</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7182</string>
+	<string>7184</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MonitorControl/Support/AppDelegate.swift
+++ b/MonitorControl/Support/AppDelegate.swift
@@ -161,7 +161,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func checkPermissions(firstAsk: Bool = false) {
-    let permissionsRequired: Bool = [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue)) || [KeyboardBrightness.media.rawValue, KeyboardBrightness.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardBrightness.rawValue))
+    let permissionsRequired: Bool = [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue, KeyboardVolume.mediaForce.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue)) || [KeyboardBrightness.media.rawValue, KeyboardBrightness.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardBrightness.rawValue))
     if !MediaKeyTapManager.readPrivileges(prompt: false), permissionsRequired {
       MediaKeyTapManager.acquirePrivileges(firstAsk: firstAsk)
     }

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -1,0 +1,225 @@
+//  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+//  CustomHUD.swift - Custom OSD overlay for macOS Tahoe 26+ compatibility
+
+import Cocoa
+
+#if swift(>=5.3)
+import SwiftUI
+#endif
+
+// MARK: - Custom HUD Manager
+
+/// Manages custom HUD windows for brightness/volume display on macOS 26+
+/// where the native OSD API no longer works correctly
+class CustomHUDManager {
+    static let shared = CustomHUDManager()
+    
+    private var hudWindows: [CGDirectDisplayID: NSWindow] = [:]
+    private let hudLock = NSLock()
+    
+    private init() {}
+    
+    /// Shows a custom HUD on the specified display
+    func showHUD(displayID: CGDirectDisplayID, type: HUDType, value: Float, maxValue: Float = 1.0) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            self.hudLock.lock()
+            defer { self.hudLock.unlock() }
+            
+            // Get or create HUD window for this display
+            let window: NSWindow
+            if let existingWindow = self.hudWindows[displayID] {
+                window = existingWindow
+            } else {
+                window = self.createHUDWindow(displayID: displayID)
+                self.hudWindows[displayID] = window
+            }
+            
+            // Update and show the HUD
+            self.updateWindowContent(window: window, displayID: displayID, type: type, value: value, maxValue: maxValue)
+            self.showWindowWithFade(window: window)
+        }
+    }
+    
+    private func createHUDWindow(displayID: CGDirectDisplayID) -> NSWindow {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 220, height: 60),
+            styleMask: [.nonactivatingPanel, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+        
+        window.level = .floating
+        window.isFloatingPanel = true
+        window.hidesOnDeactivate = false
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = true
+        window.isMovable = false
+        window.isMovableByWindowBackground = false
+        window.ignoresMouseEvents = true
+        
+        positionWindow(window, onDisplay: displayID)
+        
+        return window
+    }
+    
+    private func positionWindow(_ window: NSWindow, onDisplay displayID: CGDirectDisplayID) {
+        guard let screen = getScreen(for: displayID) else { return }
+        
+        let screenFrame = screen.visibleFrame
+        let windowSize = window.frame.size
+        
+        // Position at center-bottom of screen, above the dock
+        let x = screenFrame.origin.x + (screenFrame.width - windowSize.width) / 2
+        let y = screenFrame.origin.y + 100 // 100 points from bottom
+        
+        window.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+    
+    private func getScreen(for displayID: CGDirectDisplayID) -> NSScreen? {
+        return NSScreen.screens.first { screen in
+            guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+                return false
+            }
+            return CGDirectDisplayID(screenNumber.uint32Value) == displayID
+        }
+    }
+    
+    private func updateWindowContent(window: NSWindow, displayID: CGDirectDisplayID, type: HUDType, value: Float, maxValue: Float) {
+        // Create content view using AppKit for maximum compatibility
+        let contentView = createHUDContentView(type: type, value: value, maxValue: maxValue)
+        window.contentView = contentView
+        
+        // Re-position in case screen changed
+        positionWindow(window, onDisplay: displayID)
+    }
+    
+    private func createHUDContentView(type: HUDType, value: Float, maxValue: Float) -> NSView {
+        let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: 220, height: 60))
+        containerView.material = .hudWindow
+        containerView.blendingMode = .behindWindow
+        containerView.state = .active
+        containerView.wantsLayer = true
+        containerView.layer?.cornerRadius = 12
+        containerView.layer?.masksToBounds = true
+        
+        // Icon
+        let iconView = NSImageView(frame: NSRect(x: 16, y: 18, width: 24, height: 24))
+        if #available(macOS 11.0, *) {
+            if let icon = NSImage(systemSymbolName: type.iconSystemName, accessibilityDescription: nil) {
+                iconView.image = icon
+                iconView.contentTintColor = type.iconNSColor
+            }
+        } else {
+            // Fallback for older macOS: use bundled or system icons
+            let fallbackIcon: String
+            switch type {
+            case .brightness: fallbackIcon = NSImage.touchBarComposeTemplateName
+            case .volume: fallbackIcon = NSImage.touchBarAudioOutputVolumeHighTemplateName
+            case .volumeMuted: fallbackIcon = NSImage.touchBarAudioOutputMuteTemplateName
+            case .contrast: fallbackIcon = NSImage.touchBarColorPickerFillName
+            }
+            iconView.image = NSImage(named: fallbackIcon)
+            iconView.contentTintColor = type.iconNSColor
+        }
+        containerView.addSubview(iconView)
+        
+        // Progress bar background
+        let progressBg = NSView(frame: NSRect(x: 52, y: 26, width: 108, height: 8))
+        progressBg.wantsLayer = true
+        progressBg.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.2).cgColor
+        progressBg.layer?.cornerRadius = 4
+        containerView.addSubview(progressBg)
+        
+        // Progress bar fill
+        let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
+        let progressFill = NSView(frame: NSRect(x: 52, y: 26, width: 108 * normalizedValue, height: 8))
+        progressFill.wantsLayer = true
+        progressFill.layer?.backgroundColor = NSColor.white.cgColor
+        progressFill.layer?.cornerRadius = 4
+        containerView.addSubview(progressFill)
+        
+        // Percentage label
+        let percentage = Int(normalizedValue * 100)
+        let label = NSTextField(labelWithString: "\(percentage)%")
+        label.frame = NSRect(x: 168, y: 20, width: 42, height: 20)
+        label.font = NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .medium)
+        label.textColor = .white
+        label.alignment = .right
+        containerView.addSubview(label)
+        
+        return containerView
+    }
+    
+    private var fadeTimers: [CGDirectDisplayID: Timer] = [:]
+    
+    private func showWindowWithFade(window: NSWindow) {
+        // Find the displayID for this window
+        guard let displayID = hudWindows.first(where: { $0.value === window })?.key else { return }
+        
+        // Cancel any existing fade timer
+        fadeTimers[displayID]?.invalidate()
+        
+        // Make window fully visible
+        window.alphaValue = 1.0
+        window.orderFrontRegardless()
+        
+        // Schedule fade out after 1.5 seconds
+        fadeTimers[displayID] = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) { [weak self, weak window] _ in
+            guard let window = window else { return }
+            self?.fadeOut(window: window)
+        }
+    }
+    
+    private func fadeOut(window: NSWindow) {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.3
+            window.animator().alphaValue = 0
+        } completionHandler: {
+            window.orderOut(nil)
+        }
+    }
+    
+    /// Cleans up HUD windows for removed displays
+    func cleanupDisplay(_ displayID: CGDirectDisplayID) {
+        hudLock.lock()
+        defer { hudLock.unlock() }
+        
+        fadeTimers[displayID]?.invalidate()
+        fadeTimers.removeValue(forKey: displayID)
+        
+        if let window = hudWindows[displayID] {
+            window.close()
+            hudWindows.removeValue(forKey: displayID)
+        }
+    }
+}
+
+// MARK: - HUD Type
+
+enum HUDType {
+    case brightness
+    case volume
+    case volumeMuted
+    case contrast
+    
+    var iconSystemName: String {
+        switch self {
+        case .brightness: return "sun.max.fill"
+        case .volume: return "speaker.wave.2.fill"
+        case .volumeMuted: return "speaker.slash.fill"
+        case .contrast: return "circle.lefthalf.filled"
+        }
+    }
+    
+    var iconNSColor: NSColor {
+        switch self {
+        case .brightness: return .systemYellow
+        case .volume, .volumeMuted: return .systemBlue
+        case .contrast: return .systemGray
+        }
+    }
+}

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -44,7 +44,7 @@ class CustomHUDManager {
     
     private func createHUDWindow(displayID: CGDirectDisplayID) -> NSWindow {
         let window = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 220, height: 60),
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 56),
             styleMask: [.nonactivatingPanel, .hudWindow],
             backing: .buffered,
             defer: false
@@ -98,23 +98,35 @@ class CustomHUDManager {
     }
     
     private func createHUDContentView(type: HUDType, value: Float, maxValue: Float) -> NSView {
-        let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: 220, height: 60))
+        let w: CGFloat = 260
+        let h: CGFloat = 56
+        let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: w, height: h))
         containerView.material = .hudWindow
         containerView.blendingMode = .behindWindow
         containerView.state = .active
         containerView.wantsLayer = true
-        containerView.layer?.cornerRadius = 12
+        containerView.layer?.cornerRadius = h / 2
         containerView.layer?.masksToBounds = true
-        
-        // Icon
-        let iconView = NSImageView(frame: NSRect(x: 16, y: 18, width: 24, height: 24))
+
+        let iconSize: CGFloat = 26
+        let iconView = NSImageView(frame: NSRect(x: 18, y: (h - iconSize) / 2, width: iconSize, height: iconSize))
+        iconView.imageScaling = .scaleProportionallyDown
+        iconView.wantsLayer = true
+        iconView.layer?.isOpaque = false
+        iconView.layer?.backgroundColor = NSColor.clear.cgColor
         if #available(macOS 11.0, *) {
             if let icon = NSImage(systemSymbolName: type.iconSystemName, accessibilityDescription: nil) {
-                iconView.image = icon
-                iconView.contentTintColor = type.iconNSColor
+                if #available(macOS 12.0, *) {
+                    let base = NSImage.SymbolConfiguration(pointSize: iconSize * 0.85, weight: .semibold)
+                    let palette = NSImage.SymbolConfiguration(paletteColors: [type.iconNSColor])
+                    iconView.image = icon.withSymbolConfiguration(base.applying(palette))
+                    iconView.contentTintColor = nil
+                } else {
+                    iconView.image = icon
+                    iconView.contentTintColor = type.iconNSColor
+                }
             }
         } else {
-            // Fallback for older macOS: use bundled or system icons
             let fallbackIcon: String
             switch type {
             case .brightness: fallbackIcon = NSImage.touchBarComposeTemplateName
@@ -126,31 +138,33 @@ class CustomHUDManager {
             iconView.contentTintColor = type.iconNSColor
         }
         containerView.addSubview(iconView)
-        
-        // Progress bar background
-        let progressBg = NSView(frame: NSRect(x: 52, y: 26, width: 108, height: 8))
+
+        let barX: CGFloat = 18 + iconSize + 12
+        let barW: CGFloat = w - barX - 56
+        let barH: CGFloat = 10
+        let barY = (h - barH) / 2
+
+        let progressBg = NSView(frame: NSRect(x: barX, y: barY, width: barW, height: barH))
         progressBg.wantsLayer = true
-        progressBg.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.2).cgColor
-        progressBg.layer?.cornerRadius = 4
+        progressBg.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.22).cgColor
+        progressBg.layer?.cornerRadius = barH / 2
         containerView.addSubview(progressBg)
-        
-        // Progress bar fill
+
         let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
-        let progressFill = NSView(frame: NSRect(x: 52, y: 26, width: 108 * normalizedValue, height: 8))
+        let progressFill = NSView(frame: NSRect(x: barX, y: barY, width: max(barH, barW * normalizedValue), height: barH))
         progressFill.wantsLayer = true
         progressFill.layer?.backgroundColor = NSColor.white.cgColor
-        progressFill.layer?.cornerRadius = 4
+        progressFill.layer?.cornerRadius = barH / 2
         containerView.addSubview(progressFill)
-        
-        // Percentage label
+
         let percentage = Int(normalizedValue * 100)
         let label = NSTextField(labelWithString: "\(percentage)%")
-        label.frame = NSRect(x: 168, y: 20, width: 42, height: 20)
-        label.font = NSFont.monospacedDigitSystemFont(ofSize: 14, weight: .medium)
+        label.frame = NSRect(x: barX + barW + 8, y: (h - 22) / 2, width: 44, height: 22)
+        label.font = NSFont.monospacedDigitSystemFont(ofSize: 15, weight: .semibold)
         label.textColor = .white
         label.alignment = .right
         containerView.addSubview(label)
-        
+
         return containerView
     }
     

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -104,12 +104,17 @@ class CustomHUDManager {
         rootView.layer?.backgroundColor = NSColor.clear.cgColor
         
         let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: w, height: h))
-        containerView.material = .hudWindow
+        containerView.material = .popover
         containerView.blendingMode = .behindWindow
         containerView.state = .active
+        containerView.appearance = NSAppearance(named: .vibrantDark)
         containerView.wantsLayer = true
         containerView.layer?.cornerRadius = h / 2
         containerView.layer?.masksToBounds = true
+        
+        // Add liquid glass edge highlight
+        containerView.layer?.borderWidth = 1.0
+        containerView.layer?.borderColor = NSColor.white.withAlphaComponent(0.15).cgColor
         
         rootView.addSubview(containerView)
 
@@ -145,26 +150,28 @@ class CustomHUDManager {
         containerView.addSubview(iconView)
 
         let barX: CGFloat = 18 + iconSize + 12
-        let barW: CGFloat = w - barX - 56
+        let barW: CGFloat = w - barX - 74
         let barH: CGFloat = 10
         let barY = (h - barH) / 2
 
-        let progressBg = NSView(frame: NSRect(x: barX, y: barY, width: barW, height: barH))
-        progressBg.wantsLayer = true
-        progressBg.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.22).cgColor
-        progressBg.layer?.cornerRadius = barH / 2
+        let progressBg = NSBox(frame: NSRect(x: barX, y: barY, width: barW, height: barH))
+        progressBg.boxType = .custom
+        progressBg.borderType = .noBorder
+        progressBg.fillColor = NSColor.white.withAlphaComponent(0.22)
+        progressBg.cornerRadius = barH / 2
         containerView.addSubview(progressBg)
 
         let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
-        let progressFill = NSView(frame: NSRect(x: barX, y: barY, width: max(barH, barW * normalizedValue), height: barH))
-        progressFill.wantsLayer = true
-        progressFill.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.85).cgColor
-        progressFill.layer?.cornerRadius = barH / 2
+        let progressFill = NSBox(frame: NSRect(x: barX, y: barY, width: max(barH, barW * normalizedValue), height: barH))
+        progressFill.boxType = .custom
+        progressFill.borderType = .noBorder
+        progressFill.fillColor = NSColor.white.withAlphaComponent(0.85)
+        progressFill.cornerRadius = barH / 2
         containerView.addSubview(progressFill)
 
         let percentage = Int(normalizedValue * 100)
         let label = NSTextField(labelWithString: "\(percentage)%")
-        label.frame = NSRect(x: barX + barW + 8, y: (h - 22) / 2, width: 44, height: 22)
+        label.frame = NSRect(x: barX + barW + 12, y: (h - 22) / 2, width: 44, height: 22)
         label.font = NSFont.monospacedDigitSystemFont(ofSize: 15, weight: .semibold)
         label.textColor = .white
         label.alignment = .right

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -98,14 +98,26 @@ class CustomHUDManager {
     }
     
     private func createHUDContentView(type: HUDType, value: Float, maxValue: Float) -> NSView {
+        // Wrap in a transparent root view to fix "offending corners" and ensure perfect rounding
+        let rootView = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 60))
+        rootView.wantsLayer = true
+        rootView.layer?.backgroundColor = NSColor.clear.cgColor
+        
         let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: 220, height: 60))
-        containerView.material = .hudWindow
+        containerView.material = .popover
         containerView.blendingMode = .behindWindow
         containerView.state = .active
+        containerView.appearance = NSAppearance(named: .vibrantDark)
         containerView.wantsLayer = true
-        containerView.layer?.cornerRadius = 12
+        containerView.layer?.cornerRadius = 30 // Pill shape (height / 2)
         containerView.layer?.masksToBounds = true
         
+        // Add subtle edge highlight for a premium look
+        containerView.layer?.borderWidth = 1.0
+        containerView.layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
+        
+        rootView.addSubview(containerView)
+
         // Icon
         let iconView = NSImageView(frame: NSRect(x: 16, y: 18, width: 24, height: 24))
         if #available(macOS 11.0, *) {
@@ -138,7 +150,7 @@ class CustomHUDManager {
         let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
         let progressFill = NSView(frame: NSRect(x: 52, y: 26, width: 108 * normalizedValue, height: 8))
         progressFill.wantsLayer = true
-        progressFill.layer?.backgroundColor = NSColor.white.cgColor
+        progressFill.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.85).cgColor
         progressFill.layer?.cornerRadius = 4
         containerView.addSubview(progressFill)
         
@@ -151,7 +163,7 @@ class CustomHUDManager {
         label.alignment = .right
         containerView.addSubview(label)
         
-        return containerView
+        return rootView
     }
     
     private var fadeTimers: [CGDirectDisplayID: Timer] = [:]
@@ -217,9 +229,8 @@ enum HUDType {
     
     var iconNSColor: NSColor {
         switch self {
-        case .brightness: return .systemYellow
-        case .volume, .volumeMuted: return .systemBlue
-        case .contrast: return .systemGray
+        case .brightness, .volume, .volumeMuted: return .white.withAlphaComponent(0.9)
+        case .contrast: return .white.withAlphaComponent(0.8)
         }
     }
 }

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -158,7 +158,7 @@ class CustomHUDManager {
         let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
         let progressFill = NSView(frame: NSRect(x: barX, y: barY, width: max(barH, barW * normalizedValue), height: barH))
         progressFill.wantsLayer = true
-        progressFill.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.9).cgColor
+        progressFill.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.85).cgColor
         progressFill.layer?.cornerRadius = barH / 2
         containerView.addSubview(progressFill)
 

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -41,7 +41,7 @@ class CustomHUDManager {
     private func createHUDWindow(displayID: CGDirectDisplayID) -> NSWindow {
         let window = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 260, height: 56),
-            styleMask: [.nonactivatingPanel, .hudWindow],
+            styleMask: [.nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -96,6 +96,13 @@ class CustomHUDManager {
     private func createHUDContentView(type: HUDType, value: Float, maxValue: Float) -> NSView {
         let w: CGFloat = 260
         let h: CGFloat = 56
+        
+        // Wrap the visual effect view in a transparent root view.
+        // This ensures the NSWindow doesn't force a square opaque background on the corners.
+        let rootView = NSView(frame: NSRect(x: 0, y: 0, width: w, height: h))
+        rootView.wantsLayer = true
+        rootView.layer?.backgroundColor = NSColor.clear.cgColor
+        
         let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: w, height: h))
         containerView.material = .hudWindow
         containerView.blendingMode = .behindWindow
@@ -103,6 +110,8 @@ class CustomHUDManager {
         containerView.wantsLayer = true
         containerView.layer?.cornerRadius = h / 2
         containerView.layer?.masksToBounds = true
+        
+        rootView.addSubview(containerView)
 
         let iconSize: CGFloat = 26
         let iconView = NSImageView(frame: NSRect(x: 18, y: (h - iconSize) / 2, width: iconSize, height: iconSize))
@@ -149,7 +158,7 @@ class CustomHUDManager {
         let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
         let progressFill = NSView(frame: NSRect(x: barX, y: barY, width: max(barH, barW * normalizedValue), height: barH))
         progressFill.wantsLayer = true
-        progressFill.layer?.backgroundColor = NSColor.white.cgColor
+        progressFill.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.9).cgColor
         progressFill.layer?.cornerRadius = barH / 2
         containerView.addSubview(progressFill)
 
@@ -161,7 +170,7 @@ class CustomHUDManager {
         label.alignment = .right
         containerView.addSubview(label)
 
-        return containerView
+        return rootView
     }
     
     private var fadeTimers: [CGDirectDisplayID: Timer] = [:]
@@ -229,9 +238,9 @@ enum HUDType {
     
     var iconNSColor: NSColor {
         switch self {
-        case .brightness: return .systemYellow
-        case .volume, .volumeMuted: return .systemBlue
-        case .contrast: return .systemGray
+        case .brightness: return .white.withAlphaComponent(0.9)
+        case .volume, .volumeMuted: return .white.withAlphaComponent(0.9)
+        case .contrast: return .white.withAlphaComponent(0.8)
         }
     }
 }

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -3,10 +3,6 @@
 
 import Cocoa
 
-#if swift(>=5.3)
-import SwiftUI
-#endif
-
 // MARK: - Custom HUD Manager
 
 /// Manages custom HUD windows for brightness/volume display on macOS 26+
@@ -181,11 +177,13 @@ class CustomHUDManager {
         window.alphaValue = 1.0
         window.orderFrontRegardless()
         
-        // Schedule fade out after 1.5 seconds
-        fadeTimers[displayID] = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) { [weak self, weak window] _ in
+        // Schedule fade out after 1.5 seconds (common mode so it still fires during nested run-loop work)
+        let timer = Timer(timeInterval: 1.5, repeats: false) { [weak self, weak window] _ in
             guard let window = window else { return }
             self?.fadeOut(window: window)
         }
+        fadeTimers[displayID] = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
     
     private func fadeOut(window: NSWindow) {

--- a/MonitorControl/Support/CustomHUD.swift
+++ b/MonitorControl/Support/CustomHUD.swift
@@ -40,8 +40,8 @@ class CustomHUDManager {
     
     private func createHUDWindow(displayID: CGDirectDisplayID) -> NSWindow {
         let window = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 260, height: 56),
-            styleMask: [.nonactivatingPanel],
+            contentRect: NSRect(x: 0, y: 0, width: 280, height: 64),
+            styleMask: [.nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -56,6 +56,8 @@ class CustomHUDManager {
         window.isMovable = false
         window.isMovableByWindowBackground = false
         window.ignoresMouseEvents = true
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
         
         positionWindow(window, onDisplay: displayID)
         
@@ -70,7 +72,7 @@ class CustomHUDManager {
         
         // Position at center-bottom of screen, above the dock
         let x = screenFrame.origin.x + (screenFrame.width - windowSize.width) / 2
-        let y = screenFrame.origin.y + 100 // 100 points from bottom
+        let y = screenFrame.origin.y + 80 // 80 points from bottom for better visibility
         
         window.setFrameOrigin(NSPoint(x: x, y: y))
     }
@@ -94,17 +96,16 @@ class CustomHUDManager {
     }
     
     private func createHUDContentView(type: HUDType, value: Float, maxValue: Float) -> NSView {
-        let w: CGFloat = 260
-        let h: CGFloat = 56
+        let w: CGFloat = 280
+        let h: CGFloat = 64
         
         // Wrap the visual effect view in a transparent root view.
-        // This ensures the NSWindow doesn't force a square opaque background on the corners.
         let rootView = NSView(frame: NSRect(x: 0, y: 0, width: w, height: h))
         rootView.wantsLayer = true
         rootView.layer?.backgroundColor = NSColor.clear.cgColor
         
         let containerView = NSVisualEffectView(frame: NSRect(x: 0, y: 0, width: w, height: h))
-        containerView.material = .popover
+        containerView.material = .hudWindow
         containerView.blendingMode = .behindWindow
         containerView.state = .active
         containerView.appearance = NSAppearance(named: .vibrantDark)
@@ -112,29 +113,24 @@ class CustomHUDManager {
         containerView.layer?.cornerRadius = h / 2
         containerView.layer?.masksToBounds = true
         
-        // Add liquid glass edge highlight
-        containerView.layer?.borderWidth = 1.0
-        containerView.layer?.borderColor = NSColor.white.withAlphaComponent(0.15).cgColor
+        // Add premium liquid glass edge highlight
+        containerView.layer?.borderWidth = 0.5
+        containerView.layer?.borderColor = NSColor.white.withAlphaComponent(0.25).cgColor
         
         rootView.addSubview(containerView)
 
-        let iconSize: CGFloat = 26
-        let iconView = NSImageView(frame: NSRect(x: 18, y: (h - iconSize) / 2, width: iconSize, height: iconSize))
+        let iconSize: CGFloat = 24
+        let iconView = NSImageView(frame: NSRect(x: 20, y: (h - iconSize) / 2, width: iconSize, height: iconSize))
         iconView.imageScaling = .scaleProportionallyDown
         iconView.wantsLayer = true
         iconView.layer?.isOpaque = false
         iconView.layer?.backgroundColor = NSColor.clear.cgColor
+        
         if #available(macOS 11.0, *) {
             if let icon = NSImage(systemSymbolName: type.iconSystemName, accessibilityDescription: nil) {
-                if #available(macOS 12.0, *) {
-                    let base = NSImage.SymbolConfiguration(pointSize: iconSize * 0.85, weight: .semibold)
-                    let palette = NSImage.SymbolConfiguration(paletteColors: [type.iconNSColor])
-                    iconView.image = icon.withSymbolConfiguration(base.applying(palette))
-                    iconView.contentTintColor = nil
-                } else {
-                    iconView.image = icon
-                    iconView.contentTintColor = type.iconNSColor
-                }
+                let config = NSImage.SymbolConfiguration(pointSize: iconSize * 0.9, weight: .bold)
+                iconView.image = icon.withSymbolConfiguration(config)
+                iconView.contentTintColor = .white
             }
         } else {
             let fallbackIcon: String
@@ -145,37 +141,31 @@ class CustomHUDManager {
             case .contrast: fallbackIcon = NSImage.touchBarColorPickerFillName
             }
             iconView.image = NSImage(named: fallbackIcon)
-            iconView.contentTintColor = type.iconNSColor
+            iconView.contentTintColor = .white
         }
         containerView.addSubview(iconView)
 
-        let barX: CGFloat = 18 + iconSize + 12
-        let barW: CGFloat = w - barX - 74
-        let barH: CGFloat = 10
+        // Thick Liquid Slider
+        let barX: CGFloat = 20 + iconSize + 16
+        let barW: CGFloat = w - barX - 24 // More compact, no trailing percentage label by default
+        let barH: CGFloat = 32 // Thicker, liquid-style bar
         let barY = (h - barH) / 2
 
         let progressBg = NSBox(frame: NSRect(x: barX, y: barY, width: barW, height: barH))
         progressBg.boxType = .custom
         progressBg.borderType = .noBorder
-        progressBg.fillColor = NSColor.white.withAlphaComponent(0.22)
+        progressBg.fillColor = NSColor.white.withAlphaComponent(0.15)
         progressBg.cornerRadius = barH / 2
         containerView.addSubview(progressBg)
 
         let normalizedValue = CGFloat(min(max(value / maxValue, 0), 1))
-        let progressFill = NSBox(frame: NSRect(x: barX, y: barY, width: max(barH, barW * normalizedValue), height: barH))
+        let fillWidth = max(barH, barW * normalizedValue)
+        let progressFill = NSBox(frame: NSRect(x: barX, y: barY, width: fillWidth, height: barH))
         progressFill.boxType = .custom
         progressFill.borderType = .noBorder
-        progressFill.fillColor = NSColor.white.withAlphaComponent(0.85)
+        progressFill.fillColor = NSColor.white.withAlphaComponent(0.9)
         progressFill.cornerRadius = barH / 2
         containerView.addSubview(progressFill)
-
-        let percentage = Int(normalizedValue * 100)
-        let label = NSTextField(labelWithString: "\(percentage)%")
-        label.frame = NSRect(x: barX + barW + 12, y: (h - 22) / 2, width: 44, height: 22)
-        label.font = NSFont.monospacedDigitSystemFont(ofSize: 15, weight: .semibold)
-        label.textColor = .white
-        label.alignment = .right
-        containerView.addSubview(label)
 
         return rootView
     }

--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -311,6 +311,9 @@ class DisplayManager {
   }
 
   func clearDisplays() {
+    for display in self.displays {
+      CustomHUDManager.shared.cleanupDisplay(display.identifier)
+    }
     self.displays = []
   }
   

--- a/MonitorControl/Support/MediaKeyTapManager.swift
+++ b/MonitorControl/Support/MediaKeyTapManager.swift
@@ -150,7 +150,7 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
     if [KeyboardBrightness.media.rawValue, KeyboardBrightness.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardBrightness.rawValue)) {
       keys.append(contentsOf: [.brightnessUp, .brightnessDown])
     }
-    if [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue)) {
+    if [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue, KeyboardVolume.mediaForce.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue)) {
       keys.append(contentsOf: [.mute, .volumeUp, .volumeDown])
     }
     // Remove brightness keys if no external displays are connected, but only if brightness fine control is not active
@@ -166,8 +166,8 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
       let keysToDelete: [MediaKey] = [.brightnessUp, .brightnessDown]
       keys.removeAll { keysToDelete.contains($0) }
     }
-    // Remove volume related keys if audio device is controllable
-    if let defaultAudioDevice = app.coreAudio.defaultOutputDevice {
+    // Remove volume related keys if audio device is controllable (skip when user chose force-capture mode)
+    if prefs.integer(forKey: PrefKey.keyboardVolume.rawValue) != KeyboardVolume.mediaForce.rawValue, let defaultAudioDevice = app.coreAudio.defaultOutputDevice {
       let keysToDelete: [MediaKey] = [.volumeUp, .volumeDown, .mute]
       if prefs.integer(forKey: PrefKey.multiKeyboardVolume.rawValue) == MultiKeyboardVolume.audioDeviceNameMatching.rawValue {
         if DisplayManager.shared.updateAudioControlTargetDisplays(deviceName: defaultAudioDevice.name) == 0 {

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -103,25 +103,24 @@ class MenuHandler: NSMenu, NSMenuDelegate {
 
   func addDisplayMenuBlock(addedSliderHandlers: [SliderHandler], blockName: String, monitorSubMenu: NSMenu, numOfDisplays: Int, asSubMenu: Bool) {
     if numOfDisplays > 1, prefs.integer(forKey: PrefKey.multiSliders.rawValue) != MultiSliders.relevant.rawValue, !DEBUG_MACOS10, #available(macOS 11.0, *) {
-      class BlockView: NSView {
-        override func draw(_: NSRect) {
-          let radius = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? CGFloat(4) : CGFloat(11)
-          let outerMargin = CGFloat(15)
-          let blockRect = self.frame.insetBy(dx: outerMargin, dy: outerMargin / 2 + 2).offsetBy(dx: 0, dy: outerMargin / 2 * -1 + 7)
-          for i in 1 ... 5 {
-            let blockPath = NSBezierPath(roundedRect: blockRect.insetBy(dx: CGFloat(i) * -1, dy: CGFloat(i) * -1), xRadius: radius + CGFloat(i) * 0.5, yRadius: radius + CGFloat(i) * 0.5)
-            NSColor.black.withAlphaComponent(0.1 / CGFloat(i)).setStroke()
-            blockPath.stroke()
-          }
-          let blockPath = NSBezierPath(roundedRect: blockRect, xRadius: radius, yRadius: radius)
-          if [NSAppearance.Name.darkAqua, NSAppearance.Name.vibrantDark].contains(effectiveAppearance.name) {
-            NSColor.systemGray.withAlphaComponent(0.3).setStroke()
-            blockPath.stroke()
-          }
-          if ![NSAppearance.Name.darkAqua, NSAppearance.Name.vibrantDark].contains(effectiveAppearance.name) {
-            NSColor.white.withAlphaComponent(0.5).setFill()
-            blockPath.fill()
-          }
+      class BlockView: NSVisualEffectView {
+        override init(frame frameRect: NSRect) {
+          super.init(frame: frameRect)
+          self.material = .popover
+          self.blendingMode = .behindWindow
+          self.state = .active
+          self.isEmphasized = false
+          self.wantsLayer = true
+          let tickMarks = prefs.bool(forKey: PrefKey.showTickMarks.rawValue)
+          self.layer?.cornerRadius = tickMarks ? CGFloat(10) : CGFloat(14)
+          self.layer?.masksToBounds = true
+          self.layer?.borderWidth = 0.5
+          self.layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.45).cgColor
+        }
+
+        @available(*, unavailable)
+        required init?(coder _: NSCoder) {
+          fatalError("init(coder:) has not been implemented")
         }
       }
       var contentWidth: CGFloat = 0

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -103,19 +103,54 @@ class MenuHandler: NSMenu, NSMenuDelegate {
 
   func addDisplayMenuBlock(addedSliderHandlers: [SliderHandler], blockName: String, monitorSubMenu: NSMenu, numOfDisplays: Int, asSubMenu: Bool) {
     if numOfDisplays > 1, prefs.integer(forKey: PrefKey.multiSliders.rawValue) != MultiSliders.relevant.rawValue, !DEBUG_MACOS10, #available(macOS 11.0, *) {
+      /// Draws the original soft outer rings + inner edge; layered on top of `NSVisualEffectView` (which does not reliably call `draw(_:)`).
+      class BlockBorderOverlayView: NSView {
+        override var isOpaque: Bool { false }
+
+        override func viewDidChangeEffectiveAppearance() {
+          super.viewDidChangeEffectiveAppearance()
+          self.needsDisplay = true
+        }
+
+        override func draw(_ dirtyRect: NSRect) {
+          let radius = prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? CGFloat(4) : CGFloat(11)
+          let outerMargin = CGFloat(15)
+          let blockRect = self.bounds.insetBy(dx: outerMargin, dy: outerMargin / 2 + 2).offsetBy(dx: 0, dy: outerMargin / 2 * -1 + 7)
+          for i in 1 ... 5 {
+            let blockPath = NSBezierPath(roundedRect: blockRect.insetBy(dx: CGFloat(i) * -1, dy: CGFloat(i) * -1), xRadius: radius + CGFloat(i) * 0.5, yRadius: radius + CGFloat(i) * 0.5)
+            NSColor.black.withAlphaComponent(0.1 / CGFloat(i)).setStroke()
+            blockPath.lineWidth = 1
+            blockPath.stroke()
+          }
+          let blockPath = NSBezierPath(roundedRect: blockRect, xRadius: radius, yRadius: radius)
+          if [NSAppearance.Name.darkAqua, NSAppearance.Name.vibrantDark].contains(self.effectiveAppearance.name) {
+            NSColor.systemGray.withAlphaComponent(0.3).setStroke()
+            blockPath.lineWidth = 1
+            blockPath.stroke()
+          } else {
+            // With `NSVisualEffectView` behind, skip the old semi-opaque white fill so the material shows; keep a clear inner edge.
+            NSColor.separatorColor.withAlphaComponent(0.45).setStroke()
+            blockPath.lineWidth = 1
+            blockPath.stroke()
+          }
+        }
+      }
+
       class BlockView: NSVisualEffectView {
         override init(frame frameRect: NSRect) {
           super.init(frame: frameRect)
-          self.material = .popover
-          self.blendingMode = .behindWindow
+          // Match the surrounding NSMenu chrome (display name row above, etc.); `.popover` reads as a different panel.
+          self.material = .menu
+          self.blendingMode = .withinWindow
           self.state = .active
           self.isEmphasized = false
           self.wantsLayer = true
           let tickMarks = prefs.bool(forKey: PrefKey.showTickMarks.rawValue)
           self.layer?.cornerRadius = tickMarks ? CGFloat(10) : CGFloat(14)
           self.layer?.masksToBounds = true
-          self.layer?.borderWidth = 0.5
-          self.layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.45).cgColor
+          let borderOverlay = BlockBorderOverlayView(frame: self.bounds)
+          borderOverlay.autoresizingMask = [.width, .height]
+          self.addSubview(borderOverlay)
         }
 
         @available(*, unavailable)

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -219,8 +219,8 @@ class SliderHandler {
     self.slider = slider
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {
       slider.frame.size.width = 180
-      slider.frame.origin = NSPoint(x: 15, y: 5)
-      let view = NSView(frame: NSRect(x: 0, y: 0, width: slider.frame.width + 30 + (showPercent ? 38 : 0), height: slider.frame.height + 14))
+      slider.frame.origin = NSPoint(x: 15, y: 8)
+      let view = NSView(frame: NSRect(x: 0, y: 0, width: slider.frame.width + 30 + (showPercent ? 38 : 0), height: slider.frame.height + 42))
       view.frame.origin = NSPoint(x: 12, y: 0)
       var iconName = "circle.dashed"
       switch command {
@@ -232,13 +232,15 @@ class SliderHandler {
       let icon = SliderHandler.ClickThroughImageView()
       icon.image = NSImage(systemSymbolName: iconName, accessibilityDescription: title)
       icon.contentTintColor = NSColor.black.withAlphaComponent(0.6)
-      icon.frame = NSRect(x: view.frame.origin.x + 6.5, y: view.frame.origin.y + 13, width: 15, height: 15)
+      // Position icon at horizontal left (start), 8px above slider
+      let iconSize: CGFloat = 18
+      icon.frame = NSRect(x: slider.frame.origin.x, y: slider.frame.origin.y + slider.frame.height + 8, width: iconSize, height: iconSize)
       icon.imageAlignment = .alignCenter
       view.addSubview(slider)
       view.addSubview(icon)
       self.icon = icon
       if showPercent {
-        let percentageBox = NSTextField(frame: NSRect(x: 15 + slider.frame.size.width - 2, y: 17, width: 40, height: 12))
+        let percentageBox = NSTextField(frame: NSRect(x: 15 + slider.frame.size.width - 2, y: slider.frame.origin.y + (slider.frame.height - 12) / 2, width: 40, height: 12))
         self.setupPercentageBox(percentageBox)
         self.percentageBox = percentageBox
         view.addSubview(percentageBox)

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -29,7 +29,7 @@ class SliderHandler {
     let offsetY: CGFloat = -1.5
 
     let tickMarkKnobExtraInset: CGFloat = 4
-    let tickMarkKnobExtraRadiusMultiplier: CGFloat = 0.25
+    let tickMarkKnobExtraRadiusMultiplier: CGFloat = 0.75
 
     var numOfTickmarks: Int = 0
     var isHighlightDisplayItems: Bool = false
@@ -226,7 +226,7 @@ class SliderHandler {
     if #available(macOS 12.0, *) {
       let paletteColor: NSColor
       switch command {
-      case .brightness: paletteColor = .systemYellow
+      case .brightness: paletteColor = .labelColor.withAlphaComponent(0.85)
       default: paletteColor = .labelColor.withAlphaComponent(0.72)
       }
       let palette = NSImage.SymbolConfiguration(paletteColors: [paletteColor])
@@ -247,13 +247,23 @@ class SliderHandler {
     }
     self.slider = slider
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {
-      slider.frame.size.width = 196
+      let iconSize: CGFloat = 18
+      let iconPadding: CGFloat = 10
+      slider.frame.size.width = 180
       var sliderFrame = slider.frame
       sliderFrame.size.height = max(sliderFrame.size.height, 22)
       slider.frame = sliderFrame
-      slider.frame.origin = NSPoint(x: 15, y: 8)
-      let view = NSView(frame: NSRect(x: 0, y: 0, width: slider.frame.width + 30 + (showPercent ? 38 : 0), height: slider.frame.height + 42))
+      
+      // Horizontal layout: Icon then Slider
+      let iconX: CGFloat = 15
+      let sliderX = iconX + iconSize + iconPadding
+      slider.frame.origin = NSPoint(x: sliderX, y: 8)
+      
+      let viewWidth = sliderX + slider.frame.width + 15 + (showPercent ? 38 : 0)
+      let viewHeight = slider.frame.height + 16
+      let view = NSView(frame: NSRect(x: 0, y: 0, width: viewWidth, height: viewHeight))
       view.frame.origin = NSPoint(x: 12, y: 0)
+      
       var iconName = "circle.dashed"
       switch command {
       case .audioSpeakerVolume: iconName = "speaker.wave.2.fill"
@@ -262,23 +272,23 @@ class SliderHandler {
       default: break
       }
       let icon = SliderHandler.ClickThroughImageView()
-      let iconSize: CGFloat = 18
       icon.image = SliderHandler.menuSymbolImage(named: iconName, pointSize: iconSize, command: command)
       icon.imageScaling = .scaleProportionallyDown
       if #available(macOS 12.0, *) {
         icon.contentTintColor = nil
       } else {
-        icon.contentTintColor = command == .brightness ? NSColor.systemYellow : NSColor.labelColor.withAlphaComponent(0.72)
+        icon.contentTintColor = .labelColor.withAlphaComponent(0.72)
       }
-      // Position icon at horizontal left (start), 8px above slider
-      icon.frame = NSRect(x: slider.frame.origin.x, y: slider.frame.origin.y + slider.frame.height + 8, width: iconSize, height: iconSize)
+      
+      // Position icon to the left of the slider, vertically centered
+      icon.frame = NSRect(x: iconX, y: slider.frame.origin.y + (slider.frame.height - iconSize) / 2, width: iconSize, height: iconSize)
       icon.imageAlignment = .alignCenter
       icon.configureForMenuSymbol()
       view.addSubview(slider)
       view.addSubview(icon)
       self.icon = icon
       if showPercent {
-        let percentageBox = NSTextField(frame: NSRect(x: 15 + slider.frame.size.width - 2, y: slider.frame.origin.y + (slider.frame.height - 12) / 2, width: 40, height: 12))
+        let percentageBox = NSTextField(frame: NSRect(x: sliderX + slider.frame.size.width + 2, y: slider.frame.origin.y + (slider.frame.height - 12) / 2, width: 40, height: 12))
         self.setupPercentageBox(percentageBox)
         self.percentageBox = percentageBox
         view.addSubview(percentageBox)

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -34,6 +34,8 @@ class SliderHandler {
     var numOfTickmarks: Int = 0
     var isHighlightDisplayItems: Bool = false
     var displayHighlightItems: [CGDirectDisplayID: Float] = [:]
+    /// Matches Control Center–style volume (accent) vs. brightness (neutral fill).
+    var useAccentFill: Bool = false
 
     var isTracking: Bool = false
 
@@ -90,7 +92,7 @@ class SliderHandler {
       let barFilledWidth = (aRect.width - aRect.height) * CGFloat(maxValue) + aRect.height
       let barFilledRect = NSRect(x: aRect.origin.x, y: aRect.origin.y, width: barFilledWidth, height: aRect.height)
       let barFilled = NSBezierPath(roundedRect: barFilledRect, xRadius: barRadius, yRadius: barRadius)
-      self.barFilledFillColor.setFill()
+      (self.useAccentFill ? NSColor.controlAccentColor : self.barFilledFillColor).setFill()
       barFilled.fill()
 
       let knobMinX = aRect.origin.x + (aRect.width - aRect.height) * CGFloat(minValue)
@@ -207,6 +209,30 @@ class SliderHandler {
       subviews.first { subview in subview.hitTest(point) != nil
       }
     }
+
+    func configureForMenuSymbol() {
+      self.wantsLayer = true
+      self.layer?.isOpaque = false
+      self.layer?.backgroundColor = NSColor.clear.cgColor
+    }
+  }
+
+  /// Renders menu SF Symbols without multicolor white “matting” around fills (e.g. sun.max.fill).
+  @available(macOS 11.0, *)
+  private static func menuSymbolImage(named name: String, pointSize: CGFloat, command: Command) -> NSImage? {
+    guard let base = NSImage(systemSymbolName: name, accessibilityDescription: nil) else { return nil }
+    let weight: NSFont.Weight = .medium
+    let baseConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: weight)
+    if #available(macOS 12.0, *) {
+      let paletteColor: NSColor
+      switch command {
+      case .brightness: paletteColor = .systemYellow
+      default: paletteColor = .labelColor.withAlphaComponent(0.72)
+      }
+      let palette = NSImage.SymbolConfiguration(paletteColors: [paletteColor])
+      return base.withSymbolConfiguration(baseConfig.applying(palette))
+    }
+    return base.withSymbolConfiguration(baseConfig)
   }
 
   public init(display: Display?, command: Command, title: String = "", position _: Int = 0) {
@@ -216,9 +242,15 @@ class SliderHandler {
     let showPercent = prefs.bool(forKey: PrefKey.enableSliderPercent.rawValue)
     slider.isEnabled = true
     slider.setNumOfCustomTickmarks(prefs.bool(forKey: PrefKey.showTickMarks.rawValue) ? 5 : 0)
+    if let cell = slider.cell as? MCSliderCell {
+      cell.useAccentFill = command == .audioSpeakerVolume
+    }
     self.slider = slider
     if !DEBUG_MACOS10, #available(macOS 11.0, *) {
-      slider.frame.size.width = 180
+      slider.frame.size.width = 196
+      var sliderFrame = slider.frame
+      sliderFrame.size.height = max(sliderFrame.size.height, 22)
+      slider.frame = sliderFrame
       slider.frame.origin = NSPoint(x: 15, y: 8)
       let view = NSView(frame: NSRect(x: 0, y: 0, width: slider.frame.width + 30 + (showPercent ? 38 : 0), height: slider.frame.height + 42))
       view.frame.origin = NSPoint(x: 12, y: 0)
@@ -230,12 +262,18 @@ class SliderHandler {
       default: break
       }
       let icon = SliderHandler.ClickThroughImageView()
-      icon.image = NSImage(systemSymbolName: iconName, accessibilityDescription: title)
-      icon.contentTintColor = NSColor.black.withAlphaComponent(0.6)
-      // Position icon at horizontal left (start), 8px above slider
       let iconSize: CGFloat = 18
+      icon.image = SliderHandler.menuSymbolImage(named: iconName, pointSize: iconSize, command: command)
+      icon.imageScaling = .scaleProportionallyDown
+      if #available(macOS 12.0, *) {
+        icon.contentTintColor = nil
+      } else {
+        icon.contentTintColor = command == .brightness ? NSColor.systemYellow : NSColor.labelColor.withAlphaComponent(0.72)
+      }
+      // Position icon at horizontal left (start), 8px above slider
       icon.frame = NSRect(x: slider.frame.origin.x, y: slider.frame.origin.y + slider.frame.height + 8, width: iconSize, height: iconSize)
       icon.imageAlignment = .alignCenter
+      icon.configureForMenuSymbol()
       view.addSubview(slider)
       view.addSubview(icon)
       self.icon = icon

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -360,9 +360,7 @@ class SliderHandler {
         slider.floatValue = value
       }
     }
-    if self.percentageBox == self.percentageBox {
-      self.percentageBox?.stringValue = "" + String(Int(value * 100)) + "%"
-    }
+    self.percentageBox?.stringValue = "" + String(Int(value * 100)) + "%"
     for display in self.displays {
       slider.setHighlightItem(display.identifier, value: value)
       if self.command == .brightness, let appleDisplay = display as? AppleDisplay {
@@ -418,9 +416,7 @@ class SliderHandler {
       } else {
         slider.setDisplayHighlightItems(false)
       }
-      if self.percentageBox == self.percentageBox {
-        self.percentageBox?.stringValue = "" + String(Int(value * 100)) + "%"
-      }
+      self.percentageBox?.stringValue = "" + String(Int(value * 100)) + "%"
     }
   }
 }

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -231,7 +231,7 @@ class SliderHandler {
       }
       let icon = SliderHandler.ClickThroughImageView()
       icon.image = NSImage(systemSymbolName: iconName, accessibilityDescription: title)
-      icon.contentTintColor = NSColor.black.withAlphaComponent(0.6)
+      icon.contentTintColor = NSColor.labelColor.withAlphaComponent(0.72)
       // Position icon at horizontal left (start), 8px above slider
       let iconSize: CGFloat = 18
       icon.frame = NSRect(x: slider.frame.origin.x, y: slider.frame.origin.y + slider.frame.height + 8, width: iconSize, height: iconSize)

--- a/MonitorControl/Support/SliderHandler.swift
+++ b/MonitorControl/Support/SliderHandler.swift
@@ -14,15 +14,15 @@ class SliderHandler {
   var icon: ClickThroughImageView?
 
   class MCSliderCell: NSSliderCell {
-    let knobFillColor = NSColor(white: 1, alpha: 1)
-    let knobFillColorTracking = NSColor(white: 0.8, alpha: 1)
-    let knobStrokeColor = NSColor.systemGray.withAlphaComponent(0.5)
-    let knobShadowColor = NSColor(white: 0, alpha: 0.03)
-    let barFillColor = NSColor.systemGray.withAlphaComponent(0.2)
-    let barStrokeColor = NSColor.systemGray.withAlphaComponent(0.5)
-    let barFilledFillColor = NSColor(white: 1, alpha: 1)
-    let highlightDisplayIndicatorColor = NSColor(white: 0.85, alpha: 1) // This is visible if there is more the 2 displays
-    let tickMarkColor = NSColor.systemGray.withAlphaComponent(0.5)
+    let knobFillColor = NSColor.white.withAlphaComponent(0.9)
+    let knobFillColorTracking = NSColor.white.withAlphaComponent(0.75)
+    let knobStrokeColor = NSColor.systemGray.withAlphaComponent(0.4)
+    let knobShadowColor = NSColor(white: 0, alpha: 0.05)
+    let barFillColor = NSColor.systemGray.withAlphaComponent(0.25)
+    let barStrokeColor = NSColor.systemGray.withAlphaComponent(0.4)
+    let barFilledFillColor = NSColor.white.withAlphaComponent(0.85)
+    let highlightDisplayIndicatorColor = NSColor.white.withAlphaComponent(0.85) // This is visible if there is more the 2 displays
+    let tickMarkColor = NSColor.systemGray.withAlphaComponent(0.4)
 
     let inset: CGFloat = 3.5
     let offsetX: CGFloat = -1.5
@@ -118,7 +118,7 @@ class SliderHandler {
       }
 
       let knob = NSBezierPath(roundedRect: knobRect, xRadius: knobRadius, yRadius: knobRadius)
-      (self.isTracking ? self.knobFillColorTracking : self.knobFillColor).withAlphaComponent(knobAlpha).setFill()
+      (self.isTracking ? self.knobFillColorTracking : self.knobFillColor).withAlphaComponent(self.knobFillColor.alphaComponent * knobAlpha).setFill()
       knob.fill()
 
       if self.isHighlightDisplayItems, self.displayHighlightItems.count > 2 {
@@ -135,7 +135,8 @@ class SliderHandler {
 
       self.knobStrokeColor.withAlphaComponent(self.knobStrokeColor.alphaComponent * knobAlpha).setStroke()
       knob.stroke()
-      self.barStrokeColor.setStroke()
+      // Use a subtle stroke for the bar as well
+      self.barStrokeColor.withAlphaComponent(self.barStrokeColor.alphaComponent * (1 - knobAlpha * 0.5)).setStroke()
       bar.stroke()
     }
   }
@@ -383,21 +384,21 @@ class SliderHandler {
   }
 
   func updateIcon() {
-    // This looks hideous so I disable it for now. Maybe after a bit of tinkering it will look better
-    /*
-     if self.command == .audioSpeakerVolume {
-       let value = self.slider?.floatValue ?? 0.5
-       if value > 2/3 {
-         self.icon?.image = NSImage(systemSymbolName: "speaker.wave.3.fill", accessibilityDescription: "")
-       } else if value > 1/3 {
-         self.icon?.image = NSImage(systemSymbolName: "speaker.wave.2.fill", accessibilityDescription: "")
-       } else if value != 0 {
-         self.icon?.image = NSImage(systemSymbolName: "speaker.wave.1.fill", accessibilityDescription: "")
-       } else {
-         self.icon?.image = NSImage(systemSymbolName: "speaker.slash.fill", accessibilityDescription: "")
-       }
-     }
-     */
+    if #available(macOS 11.0, *), self.command == .audioSpeakerVolume {
+      let value = self.slider?.floatValue ?? 0.5
+      let iconName: String
+      if value > 2/3 {
+        iconName = "speaker.wave.3.fill"
+      } else if value > 1/3 {
+        iconName = "speaker.wave.2.fill"
+      } else if value > 0 {
+        iconName = "speaker.wave.1.fill"
+      } else {
+        iconName = "speaker.slash.fill"
+      }
+      let iconSize: CGFloat = 18
+      self.icon?.image = SliderHandler.menuSymbolImage(named: iconName, pointSize: iconSize, command: self.command)
+    }
   }
 
   func setValue(_ value: Float, displayID: CGDirectDisplayID = 0) {

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -709,7 +709,7 @@
             <objects>
                 <viewController storyboardIdentifier="KeyboardPrefsVC" id="eJ2-Cv-Vfp" customClass="KeyboardPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="yCl-jO-kpd">
-                        <rect key="frame" x="0.0" y="0.0" width="730" height="676"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="726"/>
                         <subviews>
                             <gridView xPlacement="leading" yPlacement="fill" rowAlignment="none" rowSpacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="bKX-vi-7gY">
                                 <rect key="frame" x="20" y="20" width="690" height="636"/>
@@ -1164,7 +1164,7 @@
                             </gridView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="bKX-vi-7gY" secondAttribute="bottom" constant="20" id="BWt-5s-vf7"/>
+                            <constraint firstAttribute="bottom" secondItem="bKX-vi-7gY" secondAttribute="bottom" constant="55" id="BWt-5s-vf7"/>
                             <constraint firstItem="bKX-vi-7gY" firstAttribute="leading" secondItem="yCl-jO-kpd" secondAttribute="leading" constant="20" id="Pdh-1U-kqr"/>
                             <constraint firstItem="bKX-vi-7gY" firstAttribute="top" secondItem="yCl-jO-kpd" secondAttribute="top" constant="20" id="fmV-It-Xaq"/>
                             <constraint firstAttribute="trailing" secondItem="bKX-vi-7gY" secondAttribute="trailing" constant="20" id="ssM-r3-qK0"/>
@@ -1280,7 +1280,7 @@
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="jz0-4Z-xVm">
                                                                     <rect key="frame" x="210" y="449" width="166" height="16"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="clipping" title="#bc-ignore!" id="6GJ-6Q-gqz">
+                                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="#bc-ignore!" id="6GJ-6Q-gqz">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1340,7 +1340,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" verticalHuggingPriority="750" id="mIA-Wh-7aB">
-                                                                    <rect key="frame" x="78" y="492" width="463" height="21"/>
+                                                                    <rect key="frame" x="78" y="490" width="463" height="28"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="#bc-ignore!" id="ibQ-4u-ClE">
                                                                         <font key="font" textStyle="title2" name=".SFNS-Regular"/>
@@ -1987,7 +1987,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField identifier="softwareNameLabel" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="dtg-g7-hZb">
-                                <rect key="frame" x="247" y="258" width="147" height="26"/>
+                                <rect key="frame" x="247" y="254" width="200" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="MonitorControl" id="1PJ-14-Bvn">
                                     <font key="font" textStyle="title1" name=".SFNS-Regular"/>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -997,13 +997,14 @@
                                     </gridCell>
                                     <gridCell row="6od-Ek-qTW" column="EiG-65-CTv" xPlacement="leading" id="pCd-dP-Y62">
                                         <popUpButton key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9oZ-JM-bxD">
-                                            <rect key="frame" x="217" y="187" width="293" height="25"/>
+                                            <rect key="frame" x="217" y="187" width="360" height="25"/>
                                             <popUpButtonCell key="cell" type="push" title="Standard keyboard volume and mute keys" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="1sy-Kd-WL5" id="gTf-PQ-2fA">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="message"/>
                                                 <menu key="menu" id="LhY-cM-Msq">
                                                     <items>
                                                         <menuItem title="Standard keyboard volume and mute keys" state="on" id="1sy-Kd-WL5"/>
+                                                        <menuItem title="Standard keys (force capture)" tag="4" id="fVk-mR-9Xp"/>
                                                         <menuItem title="Custom keyboard shortcuts" tag="1" id="4CG-0I-anB"/>
                                                         <menuItem title="Both standard and custom shortcuts" tag="2" id="QDG-SA-mRX">
                                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/MonitorControl/UI/cs.lproj/Localizable.strings
+++ b/MonitorControl/UI/cs.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 "App menu" = "Nabídka";
 
 /* Shown in the alert dialog */
-"Are you sure you want to enable a longer delay? Doing so may freeze your system and require a restart. Start at login will be disabled as a safety measure." = "Opravdu chcete zapnout delší prodlevu? Může dojít k zamrznutí systému, což by vyžadovalo restart. Volba "Spustit po přihlášení" se z bezpečnostních důvodů vypne.";
+"Are you sure you want to enable a longer delay? Doing so may freeze your system and require a restart. Start at login will be disabled as a safety measure." = "Opravdu chcete zapnout delší prodlevu? Může dojít k zamrznutí systému, což by vyžadovalo restart. Volba \\\"Spustit po přihlášení\\\" se z bezpečnostních důvodů vypne.";
 
 /* Shown in the alert dialog */
 "Are you sure you want to reset all settings?" = "Opravdu chcete obnovit všechna nastavení?";

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -415,5 +415,8 @@
 /* Class = "NSButtonCell"; title = "Show percentages"; ObjectID = "ZUu-MR-XwA"; */
 "ZUu-MR-XwA.title" = "Show percentages";
 
+/* Class = "NSMenuItem"; title = "Standard keys (force capture)"; ObjectID = "fVk-mR-9Xp"; */
+"fVk-mR-9Xp.title" = "Standard keys (force capture)";
+
 /* Class = "NSTextFieldCell"; title = "Combined dimming switchover point:"; ObjectID = "zv8-pZ-OPy"; */
 "zv8-pZ-OPy.title" = "Combined dimming switchover point:";

--- a/MonitorControl/View Controllers/Onboarding/OnboardingViewController.swift
+++ b/MonitorControl/View Controllers/Onboarding/OnboardingViewController.swift
@@ -27,7 +27,7 @@ class OnboardingViewController: NSViewController {
   // MARK: - Style
 
   private func setPermissionsButtonState() {
-    let volumePermissions: Bool = [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue))
+    let volumePermissions: Bool = [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue, KeyboardVolume.mediaForce.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue))
     let brigthnessPermissions: Bool = [KeyboardBrightness.media.rawValue, KeyboardBrightness.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardBrightness.rawValue))
     let permissionsRequired: Bool = volumePermissions || brigthnessPermissions
     let enabled: Bool = !MediaKeyTapManager.readPrivileges(prompt: false) && permissionsRequired

--- a/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
@@ -4,6 +4,7 @@ import Cocoa
 import KeyboardShortcuts
 import ServiceManagement
 import Settings
+import os.log
 
 class KeyboardPrefsViewController: NSViewController, SettingsPane {
   let paneIdentifier = Settings.PaneIdentifier.keyboard
@@ -45,6 +46,10 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
   @IBOutlet var rowCustomAudioShortcuts: NSGridRow!
   @IBOutlet var rowUseAudioMouseText: NSGridRow!
   @IBOutlet var rowUseAudioNameText: NSGridRow!
+
+  // Accessibility troubleshooting UI
+  var accessibilityHelpButton: NSButton?
+  var resetAccessibilityButton: NSButton?
 
   func updateGridLayout() {
     if self.keyboardBrightness.selectedTag() == KeyboardBrightness.media.rawValue {
@@ -141,7 +146,140 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     self.customVolumeDown.addSubview(customVolumeDownRecorder)
     self.customMute.addSubview(customMuteRecorder)
 
+    self.setupAccessibilityTroubleshootingUI()
     self.populateSettings()
+  }
+
+  // MARK: - Accessibility Troubleshooting UI
+
+  private func setupAccessibilityTroubleshootingUI() {
+    // Create container view - height matches other grid rows
+    let containerHeight: CGFloat = 25
+    let containerView = NSView()
+    containerView.translatesAutoresizingMaskIntoConstraints = false
+
+    // Create "Troubleshooting:" label to match the existing UI style
+    let label = NSTextField(labelWithString: NSLocalizedString("Troubleshooting:", comment: "Label for troubleshooting section"))
+    label.font = NSFont.systemFont(ofSize: 13)
+    label.textColor = NSColor.labelColor
+    label.alignment = .right
+    label.translatesAutoresizingMaskIntoConstraints = false
+
+    // Create help button with system help style
+    let helpButton = NSButton()
+    helpButton.bezelStyle = .helpButton
+    helpButton.title = ""
+    helpButton.toolTip = NSLocalizedString("Keyboard shortcuts troubleshooting", comment: "Tooltip for help button")
+    helpButton.target = self
+    helpButton.action = #selector(showAccessibilityHelp(_:))
+    helpButton.translatesAutoresizingMaskIntoConstraints = false
+    self.accessibilityHelpButton = helpButton
+
+    // Create Reset Accessibility button
+    let resetButton = NSButton()
+    resetButton.title = NSLocalizedString("Reset Accessibility Permission", comment: "Button to reset accessibility")
+    resetButton.bezelStyle = .rounded
+    resetButton.toolTip = NSLocalizedString("Reset and re-request accessibility permission (fixes keyboard shortcuts on macOS Tahoe)", comment: "Tooltip for reset button")
+    resetButton.target = self
+    resetButton.action = #selector(resetAccessibilityPermission(_:))
+    resetButton.translatesAutoresizingMaskIntoConstraints = false
+    self.resetAccessibilityButton = resetButton
+
+    // Add all elements to container
+    containerView.addSubview(label)
+    containerView.addSubview(helpButton)
+    containerView.addSubview(resetButton)
+
+    // Add container to the main view
+    self.view.addSubview(containerView)
+
+    // Layout constraints - positioning to match grid spacing (10px from grid bottom)
+    NSLayoutConstraint.activate([
+      // Container positioning - bottom of view with grid-like padding
+      containerView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 20),
+      containerView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
+      containerView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -18),
+      containerView.heightAnchor.constraint(equalToConstant: containerHeight),
+
+      // Label - right aligned at 212 points width to match storyboard column
+      label.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+      label.widthAnchor.constraint(equalToConstant: 210),
+      label.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+
+      // Help button - after label
+      helpButton.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 8),
+      helpButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+
+      // Reset button - after help button
+      resetButton.leadingAnchor.constraint(equalTo: helpButton.trailingAnchor, constant: 8),
+      resetButton.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+    ])
+  }
+
+  @objc func showAccessibilityHelp(_ sender: NSButton) {
+    let alert = NSAlert()
+    alert.messageText = NSLocalizedString("Keyboard Shortcuts Not Working?", comment: "Alert title")
+    alert.informativeText = NSLocalizedString("""
+On macOS Tahoe (26+), you may need to reset accessibility permissions for keyboard shortcuts to work.
+
+To fix this:
+1. Click "Reset Accessibility Permission" below
+2. When prompted, click "Open System Settings"
+3. Enable MonitorControl in the Accessibility list
+4. Restart MonitorControl if needed
+
+Alternatively, go to:
+System Settings → Privacy & Security → Accessibility
+Remove MonitorControl, then add it back.
+""", comment: "Accessibility troubleshooting guide")
+    alert.alertStyle = .informational
+    if #available(macOS 11.0, *) {
+      alert.icon = NSImage(systemSymbolName: "keyboard", accessibilityDescription: nil)
+    }
+    alert.addButton(withTitle: NSLocalizedString("OK", comment: "OK button"))
+    alert.addButton(withTitle: NSLocalizedString("Open Accessibility Settings", comment: "Button to open settings"))
+
+    let response = alert.runModal()
+    if response == .alertSecondButtonReturn {
+      self.openAccessibilitySettings()
+    }
+  }
+
+  @objc func resetAccessibilityPermission(_ sender: NSButton) {
+    let alert = NSAlert()
+    alert.messageText = NSLocalizedString("Reset Accessibility Permission?", comment: "Confirmation alert title")
+    alert.informativeText = NSLocalizedString("This will reset MonitorControl's accessibility permission. You will need to grant permission again for keyboard shortcuts to work.", comment: "Confirmation message")
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: NSLocalizedString("Reset & Re-request", comment: "Reset button"))
+    alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Cancel button"))
+
+    let response = alert.runModal()
+    guard response == .alertFirstButtonReturn else { return }
+
+    // Run tccutil to reset accessibility for this app
+    let bundleId = Bundle.main.bundleIdentifier ?? "me.guillaumeb.MonitorControl"
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+    process.arguments = ["reset", "Accessibility", bundleId]
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      os_log("Reset accessibility permission for %{public}@, exit code: %{public}d", type: .info, bundleId, process.terminationStatus)
+    } catch {
+      os_log("Failed to reset accessibility: %{public}@", type: .error, error.localizedDescription)
+    }
+
+    // Re-prompt for accessibility permission
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      MediaKeyTapManager.acquirePrivileges()
+    }
+  }
+
+  private func openAccessibilitySettings() {
+    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+      NSWorkspace.shared.open(url)
+    }
   }
 
   func populateSettings() {
@@ -224,3 +362,4 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     self.updateGridLayout()
   }
 }
+

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7168</string>
+	<string>7171</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7141</string>
+	<string>7168</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7175</string>
+	<string>7176</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7171</string>
+	<string>7175</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7176</string>
+	<string>7182</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>

--- a/MonitorControlHelper/Info.plist
+++ b/MonitorControlHelper/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>7182</string>
+	<string>7184</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSBackgroundOnly</key>


### PR DESCRIPTION
## Overview

This PR addresses UI display issues and improves macOS Tahoe (15.x) / Sequoia compatibility, with follow-up fixes for OSD behavior, keyboard volume capture, and HUD lifecycle.

## Changes Made

### UI Fixes

1. **Menu Bar Slider**
   - Redesigned layout: icon above slider (column style), left-aligned with the slider
   - Increased view height for spacing; fixed icon/slider overlap
   - Menu SF Symbols use palette configuration on macOS 12+ to avoid white “matting” around filled glyphs (e.g. brightness sun icon)

2. **Preferences — Displays Tab**
   - Fixed truncated display friendly name field (taller field, better alignment with larger fonts)

3. **Preferences — About Tab**
   - Fixed truncated application name label

4. **Preferences — Keyboard Tab**
   - Accessibility troubleshooting UI (Help, Reset Accessibility via `tccutil` where applicable)
   - **Volume control:** new option **Standard keys (force capture)** — always captures volume/mute media keys even when the default output device supports native macOS volume (same intent as community PR #1846; included here to ship with Tahoe work)
   - Volume control popup widened slightly to fit the new menu title

### macOS Tahoe / Sequoia / 26 Support

1. **Custom HUD for broken native OSD**
   - On **macOS 26+**, `OSDUtils` uses a custom HUD (`CustomHUD.swift`) instead of private `OSDManager` where native OSD no longer shows reliable percentage/updates (per project README note on Tahoe)
   - Fade-out uses `RunLoop` **common** mode so the timer still fires during nested run-loop activity
   - Removed unused SwiftUI import from `CustomHUD.swift`

2. **HUD lifecycle**
   - `DisplayManager.clearDisplays()` calls `CustomHUDManager.cleanupDisplay` per display so HUD windows/timers are not left behind after display reconnect or reconfigure

3. **Slider**
   - Fixed percentage label updates (removed tautological `percentageBox` guard)

## Files Touched (high level)

- `MonitorControl/Support/CustomHUD.swift` — custom OSD UI
- `MonitorControl/Support/OSDUtils.swift` — route to custom HUD on macOS 26+
- `MonitorControl/Support/SliderHandler.swift` — menu slider layout & symbol rendering; percentage label fix
- `MonitorControl/Support/DisplayManager.swift` — HUD cleanup when clearing displays
- `MonitorControl/Support/MediaKeyTapManager.swift` — `KeyboardVolume.mediaForce` handling
- `MonitorControl/Enums/PrefKey.swift` — `mediaForce` case
- `MonitorControl/Support/AppDelegate.swift`, `OnboardingViewController.swift` — accessibility prompts include force-capture volume mode
- `MonitorControl/UI/Base.lproj/Main.storyboard`, `MonitorControl/UI/en.lproj/Main.strings` — new volume menu item + layout
- `MonitorControl.xcodeproj/project.pbxproj`, `Info.plist` files — project / version as needed

## Testing

- Tested on macOS Tahoe 15.x (UI, sliders, prefs, accessibility flow)
- Verify custom HUD on **macOS 26+** when adjusting brightness/volume/contrast
- Verify **Standard keys (force capture)** keeps volume keys on MonitorControl when system would otherwise own them
- Unplug/replug or reconfigure displays and confirm no stray HUD windows

## Related

- Overlaps / supersedes need for **#1846** (force standard volume keys) if maintainers accept this combined PR
- Addresses UI truncation and Tahoe/Sequoia compatibility issues called out in discussions and README
