### PR TITLE
Add "Standard keys (force capture)" option to volume control dropdown

### DIFF
--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -78,6 +78,9 @@ enum PrefKey: String {
   // Use fine OSD scale for volume
   case useFineScaleVolume
 
+  // Always capture standard volume media keys even when macOS output volume is controllable
+  case forceStandardVolumeMediaKeys
+
   // Use smoothBrightness
   case disableSmoothBrightness
 

--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -78,9 +78,6 @@ enum PrefKey: String {
   // Use fine OSD scale for volume
   case useFineScaleVolume
 
-  // Always capture standard volume media keys even when macOS output volume is controllable
-  case forceStandardVolumeMediaKeys
-
   // Use smoothBrightness
   case disableSmoothBrightness
 
@@ -215,4 +212,5 @@ enum KeyboardVolume: Int {
   case custom = 1
   case both = 2
   case disabled = 3
+  case mediaForce = 4
 }

--- a/MonitorControl/Support/MediaKeyTapManager.swift
+++ b/MonitorControl/Support/MediaKeyTapManager.swift
@@ -166,8 +166,8 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
       let keysToDelete: [MediaKey] = [.brightnessUp, .brightnessDown]
       keys.removeAll { keysToDelete.contains($0) }
     }
-    // Remove volume related keys if audio device is controllable
-    if let defaultAudioDevice = app.coreAudio.defaultOutputDevice {
+    // Remove volume related keys if audio device is controllable unless the user opted into force-capturing them.
+    if !prefs.bool(forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue), let defaultAudioDevice = app.coreAudio.defaultOutputDevice {
       let keysToDelete: [MediaKey] = [.volumeUp, .volumeDown, .mute]
       if prefs.integer(forKey: PrefKey.multiKeyboardVolume.rawValue) == MultiKeyboardVolume.audioDeviceNameMatching.rawValue {
         if DisplayManager.shared.updateAudioControlTargetDisplays(deviceName: defaultAudioDevice.name) == 0 {

--- a/MonitorControl/Support/MediaKeyTapManager.swift
+++ b/MonitorControl/Support/MediaKeyTapManager.swift
@@ -150,7 +150,7 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
     if [KeyboardBrightness.media.rawValue, KeyboardBrightness.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardBrightness.rawValue)) {
       keys.append(contentsOf: [.brightnessUp, .brightnessDown])
     }
-    if [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue)) {
+    if [KeyboardVolume.media.rawValue, KeyboardVolume.both.rawValue, KeyboardVolume.mediaForce.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue)) {
       keys.append(contentsOf: [.mute, .volumeUp, .volumeDown])
     }
     // Remove brightness keys if no external displays are connected, but only if brightness fine control is not active
@@ -166,8 +166,8 @@ class MediaKeyTapManager: MediaKeyTapDelegate {
       let keysToDelete: [MediaKey] = [.brightnessUp, .brightnessDown]
       keys.removeAll { keysToDelete.contains($0) }
     }
-    // Remove volume related keys if audio device is controllable unless the user opted into force-capturing them.
-    if !prefs.bool(forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue), let defaultAudioDevice = app.coreAudio.defaultOutputDevice {
+    // Remove volume related keys if audio device is controllable (skip when user chose force-capture mode)
+    if prefs.integer(forKey: PrefKey.keyboardVolume.rawValue) != KeyboardVolume.mediaForce.rawValue, let defaultAudioDevice = app.coreAudio.defaultOutputDevice {
       let keysToDelete: [MediaKey] = [.volumeUp, .volumeDown, .mute]
       if prefs.integer(forKey: PrefKey.multiKeyboardVolume.rawValue) == MultiKeyboardVolume.audioDeviceNameMatching.rawValue {
         if DisplayManager.shared.updateAudioControlTargetDisplays(deviceName: defaultAudioDevice.name) == 0 {

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -1004,6 +1004,7 @@
                                                 <menu key="menu" id="LhY-cM-Msq">
                                                     <items>
                                                         <menuItem title="Standard keyboard volume and mute keys" state="on" id="1sy-Kd-WL5"/>
+                                                        <menuItem title="Standard keys (force capture)" tag="4" id="fVk-mR-9Xp"/>
                                                         <menuItem title="Custom keyboard shortcuts" tag="1" id="4CG-0I-anB"/>
                                                         <menuItem title="Both standard and custom shortcuts" tag="2" id="QDG-SA-mRX">
                                                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -1129,16 +1130,14 @@
                                     </gridCell>
                                     <gridCell row="73k-Ho-qxa" column="ZC2-Ja-sIb" id="auW-Op-Sd7"/>
                                     <gridCell row="73k-Ho-qxa" column="EiG-65-CTv" id="zDs-rB-tfY">
-                                        <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5mr-B4-1IW">
-                                            <rect key="frame" x="218" y="24" width="472" height="18"/>
-                                            <buttonCell key="cell" type="check" title="Force capture standard volume and mute keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="5V3-gQ-jWm">
-                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="forceStandardVolumeMediaKeysClicked:" target="eJ2-Cv-Vfp" id="w6y-tu-CZn"/>
-                                            </connections>
-                                        </button>
+                                        <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="1lU-Y6-hCU">
+                                            <rect key="frame" x="218" y="26" width="474" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" title="You can override audio device name under Displays (advanced) if needed." id="Dha-Tm-cDM">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </gridCell>
                                     <gridCell row="fUL-yd-WWe" column="ZC2-Ja-sIb" xPlacement="trailing" yPlacement="center" id="Wh1-8h-lvf">
                                         <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GO6-iW-7qg">
@@ -1182,7 +1181,6 @@
                         <outlet property="customVolumeDown" destination="cag-2Q-I9P" id="AuB-3g-Pwa"/>
                         <outlet property="customVolumeUp" destination="rFx-DX-nFb" id="DpG-Xm-lRB"/>
                         <outlet property="disableAltBrightnessKeys" destination="EJp-ld-K4l" id="WzJ-1Q-YT4"/>
-                        <outlet property="forceStandardVolumeMediaKeys" destination="5mr-B4-1IW" id="dbq-cm-WVC"/>
                         <outlet property="keyboardBrightness" destination="2NF-gh-JBU" id="3Cw-ob-T06"/>
                         <outlet property="keyboardVolume" destination="9oZ-JM-bxD" id="IJ6-6m-q0x"/>
                         <outlet property="multiKeyboardBrightness" destination="led-AW-u5j" id="14B-uk-v7Z"/>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -731,7 +731,6 @@
                                     <gridRow height="20" bottomPadding="-13" id="LHa-CM-c46"/>
                                     <gridRow bottomPadding="-10" id="ypS-k5-pR7"/>
                                     <gridRow bottomPadding="-10" id="73k-Ho-qxa"/>
-                                    <gridRow bottomPadding="-10" id="hQm-r8-g2v"/>
                                     <gridRow bottomPadding="-13" id="fUL-yd-WWe"/>
                                 </rows>
                                 <columns>
@@ -1130,19 +1129,8 @@
                                     </gridCell>
                                     <gridCell row="73k-Ho-qxa" column="ZC2-Ja-sIb" id="auW-Op-Sd7"/>
                                     <gridCell row="73k-Ho-qxa" column="EiG-65-CTv" id="zDs-rB-tfY">
-                                        <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="1lU-Y6-hCU">
-                                            <rect key="frame" x="218" y="26" width="474" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" title="You can override audio device name under Displays (advanced) if needed." id="Dha-Tm-cDM">
-                                                <font key="font" metaFont="smallSystem"/>
-                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                    </gridCell>
-                                    <gridCell row="hQm-r8-g2v" column="ZC2-Ja-sIb" id="w0h-VC-Htp"/>
-                                    <gridCell row="hQm-r8-g2v" column="EiG-65-CTv" id="VSW-2J-r2M">
                                         <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5mr-B4-1IW">
-                                            <rect key="frame" x="218" y="3" width="472" height="18"/>
+                                            <rect key="frame" x="218" y="24" width="472" height="18"/>
                                             <buttonCell key="cell" type="check" title="Force capture standard volume and mute keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="5V3-gQ-jWm">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -731,6 +731,7 @@
                                     <gridRow height="20" bottomPadding="-13" id="LHa-CM-c46"/>
                                     <gridRow bottomPadding="-10" id="ypS-k5-pR7"/>
                                     <gridRow bottomPadding="-10" id="73k-Ho-qxa"/>
+                                    <gridRow bottomPadding="-10" id="hQm-r8-g2v"/>
                                     <gridRow bottomPadding="-13" id="fUL-yd-WWe"/>
                                 </rows>
                                 <columns>
@@ -1138,6 +1139,19 @@
                                             </textFieldCell>
                                         </textField>
                                     </gridCell>
+                                    <gridCell row="hQm-r8-g2v" column="ZC2-Ja-sIb" id="w0h-VC-Htp"/>
+                                    <gridCell row="hQm-r8-g2v" column="EiG-65-CTv" id="VSW-2J-r2M">
+                                        <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5mr-B4-1IW">
+                                            <rect key="frame" x="218" y="3" width="472" height="18"/>
+                                            <buttonCell key="cell" type="check" title="Force capture standard volume and mute keys" bezelStyle="regularSquare" imagePosition="left" inset="2" id="5V3-gQ-jWm">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="forceStandardVolumeMediaKeysClicked:" target="eJ2-Cv-Vfp" id="w6y-tu-CZn"/>
+                                            </connections>
+                                        </button>
+                                    </gridCell>
                                     <gridCell row="fUL-yd-WWe" column="ZC2-Ja-sIb" xPlacement="trailing" yPlacement="center" id="Wh1-8h-lvf">
                                         <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GO6-iW-7qg">
                                             <rect key="frame" x="141" y="0.0" width="71" height="16"/>
@@ -1180,6 +1194,7 @@
                         <outlet property="customVolumeDown" destination="cag-2Q-I9P" id="AuB-3g-Pwa"/>
                         <outlet property="customVolumeUp" destination="rFx-DX-nFb" id="DpG-Xm-lRB"/>
                         <outlet property="disableAltBrightnessKeys" destination="EJp-ld-K4l" id="WzJ-1Q-YT4"/>
+                        <outlet property="forceStandardVolumeMediaKeys" destination="5mr-B4-1IW" id="dbq-cm-WVC"/>
                         <outlet property="keyboardBrightness" destination="2NF-gh-JBU" id="3Cw-ob-T06"/>
                         <outlet property="keyboardVolume" destination="9oZ-JM-bxD" id="IJ6-6m-q0x"/>
                         <outlet property="multiKeyboardBrightness" destination="led-AW-u5j" id="14B-uk-v7Z"/>

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -415,5 +415,8 @@
 /* Class = "NSButtonCell"; title = "Show percentages"; ObjectID = "ZUu-MR-XwA"; */
 "ZUu-MR-XwA.title" = "Show percentages";
 
+/* Class = "NSButtonCell"; title = "Force capture standard volume and mute keys"; ObjectID = "5V3-gQ-jWm"; */
+"5V3-gQ-jWm.title" = "Force capture standard volume and mute keys";
+
 /* Class = "NSTextFieldCell"; title = "Combined dimming switchover point:"; ObjectID = "zv8-pZ-OPy"; */
 "zv8-pZ-OPy.title" = "Combined dimming switchover point:";

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -415,8 +415,8 @@
 /* Class = "NSButtonCell"; title = "Show percentages"; ObjectID = "ZUu-MR-XwA"; */
 "ZUu-MR-XwA.title" = "Show percentages";
 
-/* Class = "NSButtonCell"; title = "Force capture standard volume and mute keys"; ObjectID = "5V3-gQ-jWm"; */
-"5V3-gQ-jWm.title" = "Force capture standard volume and mute keys";
+/* Class = "NSMenuItem"; title = "Standard keys (force capture)"; ObjectID = "fVk-mR-9Xp"; */
+"fVk-mR-9Xp.title" = "Standard keys (force capture)";
 
 /* Class = "NSTextFieldCell"; title = "Combined dimming switchover point:"; ObjectID = "zv8-pZ-OPy"; */
 "zv8-pZ-OPy.title" = "Combined dimming switchover point:";

--- a/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
@@ -33,6 +33,7 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
   @IBOutlet var multiKeyboardVolume: NSPopUpButton!
   @IBOutlet var useFineScale: NSButton!
   @IBOutlet var useFineScaleVolume: NSButton!
+  @IBOutlet var forceStandardVolumeMediaKeys: NSButton!
   @IBOutlet var separateCombinedScale: NSButton!
 
   @IBOutlet var rowKeyboardBrightnessPopUp: NSGridRow!
@@ -92,9 +93,11 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     if self.keyboardVolume.selectedTag() == KeyboardVolume.disabled.rawValue {
       self.multiKeyboardVolume.isEnabled = false
       self.useFineScaleVolume.isEnabled = false
+      self.forceStandardVolumeMediaKeys.isEnabled = false
     } else {
       self.multiKeyboardVolume.isEnabled = true
       self.useFineScaleVolume.isEnabled = true
+      self.forceStandardVolumeMediaKeys.isEnabled = true
     }
 
     if self.multiKeyboardBrightness.selectedTag() == MultiKeyboardBrightness.focusInsteadOfMouse.rawValue {
@@ -152,6 +155,7 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     self.multiKeyboardVolume.selectItem(withTag: prefs.integer(forKey: PrefKey.multiKeyboardVolume.rawValue))
     self.useFineScale.state = prefs.bool(forKey: PrefKey.useFineScaleBrightness.rawValue) ? .on : .off
     self.useFineScaleVolume.state = prefs.bool(forKey: PrefKey.useFineScaleVolume.rawValue) ? .on : .off
+    self.forceStandardVolumeMediaKeys.state = prefs.bool(forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue) ? .on : .off
     self.separateCombinedScale.state = prefs.bool(forKey: PrefKey.separateCombinedScale.rawValue) ? .on : .off
     self.updateGridLayout()
   }
@@ -187,6 +191,17 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
       prefs.set(false, forKey: PrefKey.useFineScaleVolume.rawValue)
     default: break
     }
+  }
+
+  @IBAction func forceStandardVolumeMediaKeysClicked(_ sender: NSButton) {
+    switch sender.state {
+    case .on:
+      prefs.set(true, forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue)
+    case .off:
+      prefs.set(false, forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue)
+    default: break
+    }
+    app.updateMediaKeyTap()
   }
 
   @IBAction func separateCombinedScale(_ sender: NSButton) {

--- a/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
@@ -33,7 +33,6 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
   @IBOutlet var multiKeyboardVolume: NSPopUpButton!
   @IBOutlet var useFineScale: NSButton!
   @IBOutlet var useFineScaleVolume: NSButton!
-  @IBOutlet var forceStandardVolumeMediaKeys: NSButton!
   @IBOutlet var separateCombinedScale: NSButton!
 
   @IBOutlet var rowKeyboardBrightnessPopUp: NSGridRow!
@@ -93,11 +92,9 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     if self.keyboardVolume.selectedTag() == KeyboardVolume.disabled.rawValue {
       self.multiKeyboardVolume.isEnabled = false
       self.useFineScaleVolume.isEnabled = false
-      self.forceStandardVolumeMediaKeys.isEnabled = false
     } else {
       self.multiKeyboardVolume.isEnabled = true
       self.useFineScaleVolume.isEnabled = true
-      self.forceStandardVolumeMediaKeys.isEnabled = true
     }
 
     if self.multiKeyboardBrightness.selectedTag() == MultiKeyboardBrightness.focusInsteadOfMouse.rawValue {
@@ -112,7 +109,7 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
       self.rowUseAudioNameText.isHidden = false
       self.rowUseAudioMouseText.isHidden = true
     } else {
-      self.rowUseAudioNameText.isHidden = false
+      self.rowUseAudioNameText.isHidden = true
       self.rowUseAudioMouseText.isHidden = false
     }
   }
@@ -155,7 +152,6 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     self.multiKeyboardVolume.selectItem(withTag: prefs.integer(forKey: PrefKey.multiKeyboardVolume.rawValue))
     self.useFineScale.state = prefs.bool(forKey: PrefKey.useFineScaleBrightness.rawValue) ? .on : .off
     self.useFineScaleVolume.state = prefs.bool(forKey: PrefKey.useFineScaleVolume.rawValue) ? .on : .off
-    self.forceStandardVolumeMediaKeys.state = prefs.bool(forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue) ? .on : .off
     self.separateCombinedScale.state = prefs.bool(forKey: PrefKey.separateCombinedScale.rawValue) ? .on : .off
     self.updateGridLayout()
   }
@@ -191,17 +187,6 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
       prefs.set(false, forKey: PrefKey.useFineScaleVolume.rawValue)
     default: break
     }
-  }
-
-  @IBAction func forceStandardVolumeMediaKeysClicked(_ sender: NSButton) {
-    switch sender.state {
-    case .on:
-      prefs.set(true, forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue)
-    case .off:
-      prefs.set(false, forKey: PrefKey.forceStandardVolumeMediaKeys.rawValue)
-    default: break
-    }
-    app.updateMediaKeyTap()
   }
 
   @IBAction func separateCombinedScale(_ sender: NSButton) {

--- a/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
@@ -112,7 +112,7 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
       self.rowUseAudioNameText.isHidden = false
       self.rowUseAudioMouseText.isHidden = true
     } else {
-      self.rowUseAudioNameText.isHidden = true
+      self.rowUseAudioNameText.isHidden = false
       self.rowUseAudioMouseText.isHidden = false
     }
   }


### PR DESCRIPTION
## Summary
- Add a new `KeyboardVolume.mediaForce` enum case (tag=4) as a "Standard keys (force capture)" option in the existing Volume control dropdown
- When selected, MonitorControl always captures standard volume/mute media keys — even when the default audio output device supports native macOS volume control
- Default behavior remains unchanged: the existing "Standard keyboard volume and mute keys" option still disengages when macOS can control volume natively

## Test plan
- [ ] Select "Standard keyboard volume and mute keys" (default), use an output device with native macOS volume control, and verify volume keys are handled by macOS (not MonitorControl)
- [ ] Select "Standard keys (force capture)" and verify volume keys are always captured by MonitorControl regardless of audio device
- [ ] Select "Custom keyboard shortcuts" and verify custom shortcuts work as before
- [ ] Select "Both standard and custom shortcuts" and verify both work
- [ ] Select "Disable keyboard" and verify no keys are captured

## Screen Shot
<img width="2884" height="2216" alt="CleanShot 2026-03-22 at 18 10 57@2x" src="https://github.com/user-attachments/assets/57ce4cbd-38f4-4d57-ac4a-016bc5e52b1c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)