### PR TITLE
Exclude software-dimming overlay windows from screen capture

### DIFF
--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -21,6 +21,7 @@ class DisplayManager {
     self.gammaActivityEnforcer.alphaValue = 1 * (DEBUG_GAMMA_ENFORCER ? 0.5 : 0.01)
     self.gammaActivityEnforcer.ignoresMouseEvents = true
     self.gammaActivityEnforcer.level = .screenSaver
+    self.gammaActivityEnforcer.sharingType = .none // exclude helper overlay from screen capture/recording
     self.gammaActivityEnforcer.orderFrontRegardless()
     self.gammaActivityEnforcer.collectionBehavior = [.stationary, .canJoinAllSpaces]
     os_log("Gamma activity enforcer created.", type: .info)
@@ -70,6 +71,7 @@ class DisplayManager {
       shade.backgroundColor = .clear
       shade.ignoresMouseEvents = true
       shade.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+      shade.sharingType = .none // dimming overlay must not appear in screenshots / screen recordings
       shade.orderFrontRegardless()
       shade.collectionBehavior = [.stationary, .canJoinAllSpaces, .ignoresCycle]
       shade.setFrame(screen.frame, display: true)

--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -71,7 +71,14 @@ class DisplayManager {
       shade.backgroundColor = .clear
       shade.ignoresMouseEvents = true
       shade.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
-      shade.sharingType = .none // dimming overlay must not appear in screenshots / screen recordings
+      // Hiding the shade from screen capture is only safe on real displays. On VIRTUAL
+      // displays (AirPlay / Sidecar / DisplayLink) macOS presents the display itself via
+      // screen capture, so a non-capturable shade would also disappear from the physical
+      // monitor and stop dimming it. Only opt these shades out of capture when the display
+      // is not virtual (e.g. a Mac mini HDMI / blacklisted display using shade dimming).
+      if !DisplayManager.isVirtual(displayID: displayID) {
+        shade.sharingType = .none // dimming overlay must not appear in screenshots / screen recordings
+      }
       shade.orderFrontRegardless()
       shade.collectionBehavior = [.stationary, .canJoinAllSpaces, .ignoresCycle]
       shade.setFrame(screen.frame, display: true)


### PR DESCRIPTION
## Problem

When a display is dimmed using software dimming (the black "shade" overlay), screenshots and screen recordings of that display come out darkened — the capture includes the dimming overlay. This is most visible on displays that have **no DDC and no gamma support**, such as **DisplayLink / virtual displays**, where the shade overlay is the only dimming mechanism available.

Reported in:
- #1453 (Screenshots come up blank/dark when brightness dimmed)
- #866 (Screenshot from external screen is dimmer with "Avoid gamma table manipulation")
- #1446

## Root cause

`DisplayManager.createShadeOnDisplay(...)` creates a full‑screen black `NSWindow` to act as the dimming shade, but never sets its `sharingType`. The default is `.readOnly`, so the shade window is visible to the screen‑capture system (`CGWindowList` / ScreenCaptureKit). Any screenshot or recording taken while a display is dimmed therefore captures the shade and looks dark. The same applies to the 1×1 `gammaActivityEnforcer` helper window.

## Fix

Set `sharingType = .none` on the shade windows and the gamma activity enforcer. These windows are display‑only chrome; excluding them from capture does not change what the user sees on screen — the display stays visibly dimmed, but captures are taken from the content underneath.

```swift
shade.sharingType = .none
self.gammaActivityEnforcer.sharingType = .none
```

## Verification (macOS 15, DisplayLink displays)

Enumerated MonitorControl's on‑screen windows via `CGWindowListCopyWindowInfo` and read `kCGWindowSharingState`:

| Window | Before (main) | After (this PR) |
|---|---|---|
| Window Shade for Display (full‑screen) | `1` (ReadOnly → captured) | `0` (None → excluded) |
| Gamma Activity Enforcer | `1` (captured) | `0` (excluded) |

With the fix, the dimmed display still looks dimmed to the eye, but `screencapture` of that display no longer includes the shade — screenshots come out at normal brightness. An isolated test window with `sharingType = .none` confirmed it is excluded from capture (content behind shows through) rather than rendered black.

No behavior change for users who don't use software dimming.
