### PR TITLE
Validate maximum DDC overrides

### DIFF
--- a/MonitorControl/View Controllers/Preferences/DisplaysPrefsCellView.swift
+++ b/MonitorControl/View Controllers/Preferences/DisplaysPrefsCellView.swift
@@ -281,8 +281,8 @@ class DisplaysPrefsCellView: NSTableCellView {
     let prefKey = PrefKey.maxDDCOverride
     let value = sender.stringValue
     if let display = display as? OtherDisplay {
-      if !value.isEmpty, let intValue = UInt(value) {
-        display.savePref(Int(intValue), key: prefKey, for: command)
+      if let intValue = Int(value), intValue >= 0, intValue <= 65535 {
+        display.savePref(intValue, key: prefKey, for: command)
       } else {
         display.removePref(key: prefKey, for: command)
       }


### PR DESCRIPTION
The maximum DDC override accepts any unsigned integer, then narrows it through `Int` and `UInt16`. Values above 65,535 can crash when entered or when the DDC value is converted.

Accept only values from 0 through 65,535, matching the minimum override. Invalid values clear the override as before.

ran tests: `xcodebuild -project MonitorControl.xcodeproj -scheme MonitorControl -configuration Debug -derivedDataPath /tmp/MonitorControlDerivedData CODE_SIGNING_ALLOWED=NO build` (`BUILD SUCCEEDED`)
on M1 Pro mbp 14in (macOS 26.5)
