### PR TITLE
feat: Add option to ignore built-in display in combined slider mode

### DIFF
--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -87,6 +87,9 @@ enum PrefKey: String {
   // Sliders for multiple displays
   case multiSliders
 
+  // Exclude built-in display from the combined slider
+  case combineExcludeBuiltin
+
   /* -- Display specific settings */
 
   // Enable mute DDC for display

--- a/MonitorControl/Support/DisplayManager.swift
+++ b/MonitorControl/Support/DisplayManager.swift
@@ -291,6 +291,10 @@ class DisplayManager {
     self.displays.first { CGDisplayIsBuiltin($0.identifier) != 0 }
   }
 
+  func isBuiltinExcludedFromCombinedSlider() -> Bool {
+    prefs.integer(forKey: PrefKey.multiSliders.rawValue) == MultiSliders.combine.rawValue && prefs.bool(forKey: PrefKey.combineExcludeBuiltin.rawValue)
+  }
+
   func getCurrentDisplay(byFocus: Bool = false) -> Display? {
     if byFocus {
       guard let mainDisplayID = NSScreen.main?.displayID else {
@@ -403,7 +407,11 @@ class DisplayManager {
     var currentDisplay: Display?
     if isBrightness {
       if prefs.integer(forKey: PrefKey.multiKeyboardBrightness.rawValue) == MultiKeyboardBrightness.allScreens.rawValue {
-        affectedDisplays = allDisplays
+        if self.isBuiltinExcludedFromCombinedSlider() {
+          affectedDisplays = allDisplays.filter { CGDisplayIsBuiltin($0.identifier) == 0 }
+        } else {
+          affectedDisplays = allDisplays
+        }
         return affectedDisplays
       }
       currentDisplay = self.getCurrentDisplay(byFocus: prefs.integer(forKey: PrefKey.multiKeyboardBrightness.rawValue) == MultiKeyboardBrightness.focusInsteadOfMouse.rawValue)

--- a/MonitorControl/Support/MenuHandler.swift
+++ b/MonitorControl/Support/MenuHandler.swift
@@ -56,11 +56,18 @@ class MenuHandler: NSMenu, NSMenuDelegate {
     displays = DisplayManager.shared.sortDisplaysByFriendlyName()
     let relevant = prefs.integer(forKey: PrefKey.multiSliders.rawValue) == MultiSliders.relevant.rawValue
     let combine = prefs.integer(forKey: PrefKey.multiSliders.rawValue) == MultiSliders.combine.rawValue
+    let excludeBuiltinFromCombined = DisplayManager.shared.isBuiltinExcludedFromCombinedSlider()
     let numOfDisplays = displays.filter { !$0.isDummy }.count
     if numOfDisplays != 0 {
       let asSubMenu: Bool = (displays.count > 3 && !relevant && !combine && app.macOS10()) ? true : false
       var iterator = 0
       for display in displays where (!relevant || DisplayManager.resolveEffectiveDisplayID(display.identifier) == DisplayManager.resolveEffectiveDisplayID(currentDisplay!.identifier)) && !display.isDummy {
+        if excludeBuiltinFromCombined, CGDisplayIsBuiltin(display.identifier) != 0 {
+          display.sliderHandler[.audioSpeakerVolume] = nil
+          display.sliderHandler[.contrast] = nil
+          display.sliderHandler[.brightness] = nil
+          continue
+        }
         iterator += 1
         if !relevant, !combine, iterator != 1, app.macOS10() {
           self.insertItem(NSMenuItem.separator(), at: 0)

--- a/MonitorControl/UI/Base.lproj/Main.storyboard
+++ b/MonitorControl/UI/Base.lproj/Main.storyboard
@@ -316,10 +316,10 @@
             <objects>
                 <viewController storyboardIdentifier="MenuslidersPrefsVC" id="tLm-u5-aZ2" customClass="MenuslidersPrefsViewController" customModule="MonitorControl" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="5un-m0-FM4">
-                        <rect key="frame" x="0.0" y="0.0" width="730" height="560"/>
+                        <rect key="frame" x="0.0" y="0.0" width="730" height="580"/>
                         <subviews>
                             <gridView xPlacement="leading" yPlacement="fill" rowAlignment="none" rowSpacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ZrF-7t-BP5">
-                                <rect key="frame" x="20" y="20" width="690" height="520"/>
+                                <rect key="frame" x="20" y="20" width="690" height="540"/>
                                 <rows>
                                     <gridRow height="20" bottomPadding="-6" id="jyr-gk-BEN"/>
                                     <gridRow height="20" bottomPadding="-13" id="ZS3-Gy-pfA"/>
@@ -334,7 +334,8 @@
                                     <gridRow bottomPadding="-13" id="xbz-Tf-py0"/>
                                     <gridRow bottomPadding="-10" id="KPA-bi-7h3"/>
                                     <gridRow bottomPadding="-13" id="CuW-77-ls4"/>
-                                    <gridRow bottomPadding="-10" id="MaK-MK-gRQ"/>
+                                    <gridRow bottomPadding="-6" id="MaK-MK-gRQ"/>
+                                    <gridRow bottomPadding="-10" id="kD8-mX-4qP"/>
                                     <gridRow bottomPadding="-10" id="7kD-xD-py0"/>
                                     <gridRow bottomPadding="-13" id="BmS-ju-SrX"/>
                                     <gridRow height="28" bottomPadding="-10" id="dqd-4Y-f2g"/>
@@ -580,6 +581,19 @@
                                             </textFieldCell>
                                         </textField>
                                     </gridCell>
+                                    <gridCell row="kD8-mX-4qP" column="FRJ-Rb-RRh" id="gT2-vB-8wZ"/>
+                                    <gridCell row="kD8-mX-4qP" column="V6M-Jv-Agj" id="mN5-pQ-3rT">
+                                        <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cV9-xL-6yU">
+                                            <rect key="frame" x="218" y="143" width="472" height="18"/>
+                                            <buttonCell key="cell" type="check" title="Ignore built-in display" bezelStyle="regularSquare" imagePosition="left" inset="2" id="bN3-zK-9fD">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="combineExcludeBuiltinClicked:" target="tLm-u5-aZ2" id="fG4-hJ-1sA"/>
+                                            </connections>
+                                        </button>
+                                    </gridCell>
                                     <gridCell row="7kD-xD-py0" column="FRJ-Rb-RRh" headOfMergedCell="zOL-GT-1cQ" id="zOL-GT-1cQ">
                                         <box key="contentView" autoresizesSubviews="NO" horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" placeholderIntrinsicWidth="690" placeholderIntrinsicHeight="2" verifyAmbiguity="off" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ASF-dP-OR6">
                                             <rect key="frame" x="0.0" y="153" width="690" height="6"/>
@@ -680,12 +694,14 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="combineExcludeBuiltin" destination="cV9-xL-6yU" id="jH6-kD-2wE"/>
                         <outlet property="enableSliderPercent" destination="fkJ-cg-1cE" id="nba-Qb-Hor"/>
                         <outlet property="enableSliderSnap" destination="lao-JI-LJH" id="HGa-Fb-E7e"/>
                         <outlet property="iconShow" destination="TFy-Wt-ZJK" id="M96-eG-p5Q"/>
                         <outlet property="menuItemStyle" destination="6td-Zq-3e7" id="yMt-fU-PZX"/>
                         <outlet property="multiSliders" destination="78Q-P6-b97" id="uJP-0H-YuL"/>
                         <outlet property="quitApplication" destination="dy4-nH-cIr" id="aXV-0Q-H4L"/>
+                        <outlet property="rowCombineExcludeBuiltin" destination="kD8-mX-4qP" id="lK8-nM-5xF"/>
                         <outlet property="rowMenuItemStyle" destination="ZS3-Gy-pfA" id="tVN-WD-eoa"/>
                         <outlet property="rowMultiSliders" destination="CuW-77-ls4" id="XPi-6a-J58"/>
                         <outlet property="rowQuitButton" destination="AKq-Nb-ugC" id="yym-xx-O9Z"/>

--- a/MonitorControl/UI/cs.lproj/Main.strings
+++ b/MonitorControl/UI/cs.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Podle toho, kde je kurzor myši";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignorovat vestavěný displej";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Jeden posuvník pro všechny displeje";
 

--- a/MonitorControl/UI/de.lproj/Main.strings
+++ b/MonitorControl/UI/de.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Abhängig von der Mauszeigerposition";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Eingebautes Display ignorieren";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Kombinierten Regler für alle Monitore verwenden";
 

--- a/MonitorControl/UI/en.lproj/Main.strings
+++ b/MonitorControl/UI/en.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Depends on mouse pointer position";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignore built-in display";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Use combined slider for all displays";
 

--- a/MonitorControl/UI/es.lproj/Main.strings
+++ b/MonitorControl/UI/es.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Depender de la posición del cursor del ratón";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignorar la pantalla integrada";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Usar slider combinado para todas las pantallas";
 

--- a/MonitorControl/UI/fr.lproj/Main.strings
+++ b/MonitorControl/UI/fr.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Dépend de la position du pointeur de la souris";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignorer l'écran intégré";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Utiliser un curseur combiné pour tous les écrans";
 

--- a/MonitorControl/UI/hi.lproj/Main.strings
+++ b/MonitorControl/UI/hi.lproj/Main.strings
@@ -332,6 +332,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "माउस सूचक की स्थिति पर निर्भर करता है";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "बिल्ट-इन डिस्प्ले को अनदेखा करें";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "सभी प्रदर्शनों के लिए संयुक्त स्लाइडर का उपयोग करें";
 

--- a/MonitorControl/UI/hu.lproj/Main.strings
+++ b/MonitorControl/UI/hu.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Az egérmutató helyzetétől függ";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Beépített kijelző figyelmen kívül hagyása";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Kombinált csúszka az összes kijelző számára";
 

--- a/MonitorControl/UI/it.lproj/Main.strings
+++ b/MonitorControl/UI/it.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Dipende dalla posizione del puntatore del mouse";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignora il display integrato";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Utlizza uno slider combinato per tutti i monitor";
 

--- a/MonitorControl/UI/ja.lproj/Main.strings
+++ b/MonitorControl/UI/ja.lproj/Main.strings
@@ -332,6 +332,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "マウスポインタの位置に依存";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "内蔵ディスプレイを無視する";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "すべてのディスプレイが結合されたスライダーを使用";
 

--- a/MonitorControl/UI/ko.lproj/Main.strings
+++ b/MonitorControl/UI/ko.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "마우스 포인터 위치에 따라 다름";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "내장 디스플레이 무시";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "모든 디스플레이에 대한 통합 슬라이더 사용";
 

--- a/MonitorControl/UI/nl.lproj/Main.strings
+++ b/MonitorControl/UI/nl.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Afhankelijk van de positie van de muisaanwijzer";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Negeer ingebouwd beeldscherm";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Gecombineerde schuifregelaar gebruiken voor alle schermen";
 

--- a/MonitorControl/UI/pl.lproj/Main.strings
+++ b/MonitorControl/UI/pl.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Zależne od położenia wskaźnika myszy";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignoruj wbudowany wyświetlacz";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Użyj wspólnego suwaka dla wszystkich wyświetlaczy";
 

--- a/MonitorControl/UI/pt-BR.lproj/Main.strings
+++ b/MonitorControl/UI/pt-BR.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Depende da posição do ponteiro do mouse";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignorar a tela integrada";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Use o controle deslizante combinado para todos os monitores";
 

--- a/MonitorControl/UI/pt-PT.lproj/Main.strings
+++ b/MonitorControl/UI/pt-PT.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Depende da posição do ponteiro do rato";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignorar o ecrã integrado";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Usa o controlo deslizante combinado para todos os monitores";
 

--- a/MonitorControl/UI/ru.lproj/Main.strings
+++ b/MonitorControl/UI/ru.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Зависит от положения указателя мыши";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Игнорировать встроенный дисплей";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Использовать комбинированный ползунок для всех дисплеев";
 

--- a/MonitorControl/UI/sk.lproj/Main.strings
+++ b/MonitorControl/UI/sk.lproj/Main.strings
@@ -311,6 +311,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Závisí od polohy ukazovateľa myši";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Ignorovať vstavaný displej";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Použiť kombinovaný posuvník pre všetky displeje";
 

--- a/MonitorControl/UI/tr.lproj/Main.strings
+++ b/MonitorControl/UI/tr.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "Fare işaretçisinin konumuna bağlıdır";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "Yerleşik ekranı yok say";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "Tüm ekranlar için birleşik kaydırıcıyı kullanın";
 

--- a/MonitorControl/UI/zh-Hans.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "取决于鼠标指针位置";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "忽略内建显示器";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "使用一个滑杆控制所有显示器";
 

--- a/MonitorControl/UI/zh-Hant-TW.lproj/Main.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/Main.strings
@@ -226,6 +226,9 @@
 /* Class = "NSMenuItem"; title = "Depends on mouse pointer position"; ObjectID = "km4-hK-auM"; */
 "km4-hK-auM.title" = "取決於滑鼠游標位置";
 
+/* Class = "NSButtonCell"; title = "Ignore built-in display"; ObjectID = "bN3-zK-9fD"; */
+"bN3-zK-9fD.title" = "忽略內建顯示器";
+
 /* Class = "NSMenuItem"; title = "Use combined slider for all displays"; ObjectID = "lA0-tv-qRs"; */
 "lA0-tv-qRs.title" = "使用單一滑桿控制所有螢幕";
 

--- a/MonitorControl/View Controllers/Preferences/MenuslidersPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/MenuslidersPrefsViewController.swift
@@ -38,6 +38,8 @@ class MenuslidersPrefsViewController: NSViewController, SettingsPane {
 
   @IBOutlet var rowMultiSliders: NSGridRow!
   @IBOutlet var rowSlidersCombineText: NSGridRow!
+  @IBOutlet var rowCombineExcludeBuiltin: NSGridRow!
+  @IBOutlet var combineExcludeBuiltin: NSButton!
 
   @IBOutlet var rowTickCheck: NSGridRow!
   @IBOutlet var rowTickText: NSGridRow!
@@ -60,12 +62,15 @@ class MenuslidersPrefsViewController: NSViewController, SettingsPane {
     if self.multiSliders.selectedTag() == MultiSliders.separate.rawValue {
       self.rowMultiSliders.bottomPadding = -6
       self.rowSlidersCombineText.isHidden = true
+      self.rowCombineExcludeBuiltin.isHidden = true
     } else if self.multiSliders.selectedTag() == MultiSliders.relevant.rawValue {
       self.rowMultiSliders.bottomPadding = -6
       self.rowSlidersCombineText.isHidden = true
+      self.rowCombineExcludeBuiltin.isHidden = true
     } else if self.multiSliders.selectedTag() == MultiSliders.combine.rawValue {
       self.rowMultiSliders.bottomPadding = -10
       self.rowSlidersCombineText.isHidden = false
+      self.rowCombineExcludeBuiltin.isHidden = false
     }
 
     if app.macOS10() {
@@ -97,6 +102,7 @@ class MenuslidersPrefsViewController: NSViewController, SettingsPane {
     self.showContrastSlider.state = prefs.bool(forKey: PrefKey.showContrast.rawValue) ? .on : .off
 
     self.multiSliders.selectItem(withTag: prefs.integer(forKey: PrefKey.multiSliders.rawValue))
+    self.combineExcludeBuiltin.state = prefs.bool(forKey: PrefKey.combineExcludeBuiltin.rawValue) ? .on : .off
 
     self.showVolumeSlider.state = prefs.bool(forKey: PrefKey.hideVolume.rawValue) ? .off : .on
     self.enableSliderSnap.state = prefs.bool(forKey: PrefKey.enableSliderSnap.rawValue) ? .on : .off
@@ -186,6 +192,17 @@ class MenuslidersPrefsViewController: NSViewController, SettingsPane {
     prefs.set(sender.selectedTag(), forKey: PrefKey.multiSliders.rawValue)
     app.updateMenusAndKeys()
     self.updateGridLayout()
+  }
+
+  @IBAction func combineExcludeBuiltinClicked(_ sender: NSButton) {
+    switch sender.state {
+    case .on:
+      prefs.set(true, forKey: PrefKey.combineExcludeBuiltin.rawValue)
+    case .off:
+      prefs.set(false, forKey: PrefKey.combineExcludeBuiltin.rawValue)
+    default: break
+    }
+    app.updateMenusAndKeys()
   }
 
   @IBAction func showTickMarks(_ sender: NSButton) {


### PR DESCRIPTION
# Add option to ignore built-in display in combined slider mode

## Summary

When **"Use combined slider for all displays"** is enabled, the combined slider also controls the built-in MacBook display. Since the built-in display gets **significantly brighter** than typical external monitors at the same relative setting, it always stands out — making the combined slider practically unusable in everyday use.

This PR adds a new **"Ignore built-in display"** checkbox, shown only when combined slider mode is selected. When enabled, the built-in display is excluded from combined control.

## What changed

- **New checkbox** in *Settings → App menu → Multiple displays*, visible only when *"Use combined slider for all displays"* is selected (same show/hide behavior as the existing hint text below the popup)
- **Menu slider**: the built-in display is no longer added to the combined slider handler, so the slider only controls external displays
- **Keyboard control**: when *"All screens"* is selected for keyboard brightness, the built-in display is filtered out of the affected displays as well (both media keys and custom shortcuts go through `getAffectedDisplays`, so both paths are covered with a single change)
- The built-in display's brightness remains fully controllable via Control Center / System Settings

## Implementation notes

- New preference key `combineExcludeBuiltin` (defaults to off — no behavior change for existing users)
- The condition (combined mode + option enabled) is encapsulated in `DisplayManager.isBuiltinExcludedFromCombinedSlider()` and used by both `MenuHandler` and `DisplayManager.getAffectedDisplays()`
- Localizations added for all 20 languages (following the pattern of #1817)

## Screenshots

<img width="603" height="108" alt="image" src="https://github.com/user-attachments/assets/287943f1-54bf-46f2-bbc9-b07d67c99ad7" />

## How to test

1. Settings → App menu → Multiple displays → select *"Use combined slider for all displays"*
2. Enable the new *"Ignore built-in display"* checkbox
3. Move the combined brightness slider in the menu → only external displays change, built-in display stays
4. Press brightness keys (with keyboard brightness set to *"All screens"*) → again only external displays change
5. Disable the checkbox → built-in display is controlled together with all displays again
