### PR TITLE
Add brightness presets and a monitorcontrol:// URL scheme

### DIFF
--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		F06792F6200A745F0066C438 /* MonitorControlHelper.app in [Login] Copy Helper to start at Login */ = {isa = PBXBuildFile; fileRef = F06792E7200A73460066C438 /* MonitorControlHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F0A489C4279C71B200BEDFD6 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A489C3279C71B200BEDFD6 /* OnboardingViewController.swift */; };
 		FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E0895249D584C003A50BB /* OSDUtils.swift */; };
+		E1A0C0012B01000100000001 /* BrightnessActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0C0022B01000100000002 /* BrightnessActions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -181,6 +182,7 @@
 		FB5DB28F2AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InternetAccessPolicy.strings"; sourceTree = "<group>"; };
 		FB5DB2902AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FE4E0895249D584C003A50BB /* OSDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDUtils.swift; sourceTree = "<group>"; };
+		E1A0C0022B01000100000002 /* BrightnessActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessActions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -317,6 +319,7 @@
 				AA16139A26BE772E00DCF027 /* Arm64DDC.swift */,
 				AA4398A826DD55DA00943F16 /* IntelDDC.swift */,
 				FE4E0895249D584C003A50BB /* OSDUtils.swift */,
+				E1A0C0022B01000100000002 /* BrightnessActions.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				AA062E8E26CA7BE5007E628C /* DisplaysPrefsCellView.swift in Sources */,
 				AA25F6D726E68C160087F3A2 /* MediaKeyTapManager.swift in Sources */,
 				FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */,
+				E1A0C0012B01000100000001 /* BrightnessActions.swift in Sources */,
 				6CBFE27A23DB266000D1BC41 /* Display.swift in Sources */,
 				AA44E70727038F7F00E06865 /* KeyboardShortcutsManager.swift in Sources */,
 				F03A8DF21FFBAA6F0034DC27 /* OtherDisplay.swift in Sources */,

--- a/MonitorControl.xcodeproj/project.pbxproj
+++ b/MonitorControl.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		F06792F6200A745F0066C438 /* MonitorControlHelper.app in [Login] Copy Helper to start at Login */ = {isa = PBXBuildFile; fileRef = F06792E7200A73460066C438 /* MonitorControlHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F0A489C4279C71B200BEDFD6 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A489C3279C71B200BEDFD6 /* OnboardingViewController.swift */; };
 		FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4E0895249D584C003A50BB /* OSDUtils.swift */; };
+		E1A0C0032B01000100000003 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0C0042B01000100000004 /* URLSchemeHandler.swift */; };
 		E1A0C0012B01000100000001 /* BrightnessActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0C0022B01000100000002 /* BrightnessActions.swift */; };
 /* End PBXBuildFile section */
 
@@ -182,6 +183,7 @@
 		FB5DB28F2AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InternetAccessPolicy.strings"; sourceTree = "<group>"; };
 		FB5DB2902AD54C4600306223 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FE4E0895249D584C003A50BB /* OSDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSDUtils.swift; sourceTree = "<group>"; };
+		E1A0C0042B01000100000004 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
 		E1A0C0022B01000100000002 /* BrightnessActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrightnessActions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -319,6 +321,7 @@
 				AA16139A26BE772E00DCF027 /* Arm64DDC.swift */,
 				AA4398A826DD55DA00943F16 /* IntelDDC.swift */,
 				FE4E0895249D584C003A50BB /* OSDUtils.swift */,
+				E1A0C0042B01000100000004 /* URLSchemeHandler.swift */,
 				E1A0C0022B01000100000002 /* BrightnessActions.swift */,
 			);
 			path = Support;
@@ -632,6 +635,7 @@
 				AA062E8E26CA7BE5007E628C /* DisplaysPrefsCellView.swift in Sources */,
 				AA25F6D726E68C160087F3A2 /* MediaKeyTapManager.swift in Sources */,
 				FE4E0896249D584C003A50BB /* OSDUtils.swift in Sources */,
+				E1A0C0032B01000100000003 /* URLSchemeHandler.swift in Sources */,
 				E1A0C0012B01000100000001 /* BrightnessActions.swift in Sources */,
 				6CBFE27A23DB266000D1BC41 /* Display.swift in Sources */,
 				AA44E70727038F7F00E06865 /* KeyboardShortcutsManager.swift in Sources */,

--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -90,6 +90,18 @@ enum PrefKey: String {
   // Ignore the monitorcontrol:// URL scheme
   case disableExternalControl
 
+  // Brightness percentage for the first preset shortcut
+  case brightnessPreset1
+
+  // Brightness percentage for the second preset shortcut
+  case brightnessPreset2
+
+  // Brightness percentage for the third preset shortcut
+  case brightnessPreset3
+
+  // Brightness percentage for the fourth preset shortcut
+  case brightnessPreset4
+
   /* -- Display specific settings */
 
   // Enable mute DDC for display

--- a/MonitorControl/Enums/PrefKey.swift
+++ b/MonitorControl/Enums/PrefKey.swift
@@ -87,6 +87,9 @@ enum PrefKey: String {
   // Sliders for multiple displays
   case multiSliders
 
+  // Ignore the monitorcontrol:// URL scheme
+  case disableExternalControl
+
   /* -- Display specific settings */
 
   // Enable mute DDC for display

--- a/MonitorControl/Extensions/KeyboardShortcuts+Extension.swift
+++ b/MonitorControl/Extensions/KeyboardShortcuts+Extension.swift
@@ -11,5 +11,21 @@ extension KeyboardShortcuts.Name {
   static let volumeDown = Self("volumeDown")
   static let mute = Self("mute")
 
+  static let brightnessPreset1 = Self("brightnessPreset1")
+  static let brightnessPreset2 = Self("brightnessPreset2")
+  static let brightnessPreset3 = Self("brightnessPreset3")
+  static let brightnessPreset4 = Self("brightnessPreset4")
+
   static let none = Self("none")
+}
+
+extension BrightnessPreset {
+  var shortcutName: KeyboardShortcuts.Name {
+    switch self {
+    case .first: return .brightnessPreset1
+    case .second: return .brightnessPreset2
+    case .third: return .brightnessPreset3
+    case .fourth: return .brightnessPreset4
+    }
+  }
 }

--- a/MonitorControl/Info.plist
+++ b/MonitorControl/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>monitorcontrol</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>7141</string>
 	<key>LSApplicationCategoryType</key>

--- a/MonitorControl/Support/AppDelegate.swift
+++ b/MonitorControl/Support/AppDelegate.swift
@@ -86,6 +86,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     return true
   }
 
+  func application(_: NSApplication, open urls: [URL]) {
+    URLSchemeHandler.handle(urls)
+  }
+
   func applicationWillTerminate(_: Notification) {
     os_log("Goodbye!", type: .info)
     DisplayManager.shared.resetSwBrightnessForAllDisplays(noPrefSave: true)

--- a/MonitorControl/Support/BrightnessActions.swift
+++ b/MonitorControl/Support/BrightnessActions.swift
@@ -20,9 +20,11 @@ enum BrightnessActions {
   ///     clamped.
   ///   - allDisplays: Set this to true to change every display. If it is false,
   ///     the app uses the display selection from the settings.
+  ///   - minimum: The lowest level to allow. Outside callers use this to keep a
+  ///     screen from going fully black.
   /// - Returns: The number of displays that changed.
-  @discardableResult static func setLevel(_ value: Float, allDisplays: Bool = false) -> Int {
-    let target = max(0, min(1, value))
+  @discardableResult static func setLevel(_ value: Float, allDisplays: Bool = false, minimum: Float = 0) -> Int {
+    let target = max(minimum, min(1, value))
     var changed = 0
     for display in self.targetDisplays(allDisplays: allDisplays) where self.apply(target, to: display) {
       changed += 1
@@ -39,11 +41,12 @@ enum BrightnessActions {
   /// - Parameters:
   ///   - delta: The amount to add, from -1 to 1.
   ///   - allDisplays: Set this to true to change every display.
+  ///   - minimum: The lowest level to allow.
   /// - Returns: The number of displays that changed.
-  @discardableResult static func changeLevel(by delta: Float, allDisplays: Bool = false) -> Int {
+  @discardableResult static func changeLevel(by delta: Float, allDisplays: Bool = false, minimum: Float = 0) -> Int {
     var changed = 0
     for display in self.targetDisplays(allDisplays: allDisplays) {
-      let target = max(0, min(1, display.getBrightness() + delta))
+      let target = max(minimum, min(1, display.getBrightness() + delta))
       if self.apply(target, to: display) {
         changed += 1
       }

--- a/MonitorControl/Support/BrightnessActions.swift
+++ b/MonitorControl/Support/BrightnessActions.swift
@@ -89,3 +89,52 @@ enum BrightnessActions {
     return true
   }
 }
+
+/// A fixed brightness level the user can put on a keyboard shortcut.
+///
+/// A preset always changes every display. A preset is a scene, so a level that
+/// reached only the display under the pointer would be of little use.
+enum BrightnessPreset: Int, CaseIterable {
+  case first
+  case second
+  case third
+  case fourth
+
+  /// The level to use while the user has not set one. Without this a new
+  /// install would put every preset at 0 percent, which is a black screen.
+  var defaultPercentage: Int {
+    switch self {
+    case .first: return 10
+    case .second: return 50
+    case .third: return 75
+    case .fourth: return 100
+    }
+  }
+
+  var prefKey: PrefKey {
+    switch self {
+    case .first: return .brightnessPreset1
+    case .second: return .brightnessPreset2
+    case .third: return .brightnessPreset3
+    case .fourth: return .brightnessPreset4
+    }
+  }
+
+  /// The level this preset sets, from 0 to 100.
+  var percentage: Int {
+    get {
+      guard prefs.object(forKey: self.prefKey.rawValue) != nil else {
+        return self.defaultPercentage
+      }
+      return max(0, min(100, prefs.integer(forKey: self.prefKey.rawValue)))
+    }
+    nonmutating set {
+      prefs.set(max(0, min(100, newValue)), forKey: self.prefKey.rawValue)
+    }
+  }
+
+  /// Sets every display to the level of this preset.
+  func apply() {
+    BrightnessActions.setLevel(Float(self.percentage) / 100, allDisplays: true)
+  }
+}

--- a/MonitorControl/Support/BrightnessActions.swift
+++ b/MonitorControl/Support/BrightnessActions.swift
@@ -1,0 +1,88 @@
+//  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+
+import Foundation
+import os.log
+
+/// Sets the brightness of the affected displays to an absolute level, or
+/// changes it by a relative amount.
+///
+/// The preset keyboard shortcuts and the `monitorcontrol://` URL scheme both
+/// call in here, so the two entry points always behave the same way.
+enum BrightnessActions {
+  /// The lowest level an outside caller can set. It stops a stray URL from
+  /// making every screen fully black.
+  static let externalMinimumValue: Float = 0.01
+
+  /// Sets the brightness of the affected displays.
+  ///
+  /// - Parameters:
+  ///   - value: The new brightness, from 0 to 1. Values outside that range are
+  ///     clamped.
+  ///   - allDisplays: Set this to true to change every display. If it is false,
+  ///     the app uses the display selection from the settings.
+  /// - Returns: The number of displays that changed.
+  @discardableResult static func setLevel(_ value: Float, allDisplays: Bool = false) -> Int {
+    let target = max(0, min(1, value))
+    var changed = 0
+    for display in self.targetDisplays(allDisplays: allDisplays) where self.apply(target, to: display) {
+      changed += 1
+    }
+    os_log("Brightness set to %{public}@ on %{public}@ display(s)", type: .info, String(target), String(changed))
+    return changed
+  }
+
+  /// Changes the brightness of the affected displays by a relative amount.
+  ///
+  /// The app does the arithmetic per display, so a caller does not need to read
+  /// the current level first.
+  ///
+  /// - Parameters:
+  ///   - delta: The amount to add, from -1 to 1.
+  ///   - allDisplays: Set this to true to change every display.
+  /// - Returns: The number of displays that changed.
+  @discardableResult static func changeLevel(by delta: Float, allDisplays: Bool = false) -> Int {
+    var changed = 0
+    for display in self.targetDisplays(allDisplays: allDisplays) {
+      let target = max(0, min(1, display.getBrightness() + delta))
+      if self.apply(target, to: display) {
+        changed += 1
+      }
+    }
+    os_log("Brightness changed by %{public}@ on %{public}@ display(s)", type: .info, String(delta), String(changed))
+    return changed
+  }
+
+  /// Returns the displays a brightness action applies to, without the ones the
+  /// user disabled.
+  private static func targetDisplays(allDisplays: Bool) -> [Display] {
+    guard app.sleepID == 0, app.reconfigureID == 0 else {
+      return []
+    }
+    let displays: [Display]
+    if allDisplays {
+      displays = DisplayManager.shared.getAllDisplays()
+    } else {
+      displays = DisplayManager.shared.getAffectedDisplays(isBrightness: true, isVolume: false) ?? []
+    }
+    return displays.filter { !$0.readPrefAsBool(key: .isDisabled) }
+  }
+
+  /// Sets one display and performs the same side effects as a brightness key
+  /// press: the OSD, the menu slider, and the value the brightness sync reads.
+  private static func apply(_ value: Float, to display: Display) -> Bool {
+    guard !display.readPrefAsBool(key: .unavailableDDC, for: .brightness), display.setBrightness(value) else {
+      return false
+    }
+    if !display.readPrefAsBool(key: .hideOsd) {
+      OSDUtils.showOsd(displayID: display.identifier, command: .brightness, value: value * 64, maxValue: 64)
+    }
+    if let slider = display.sliderHandler[.brightness] {
+      slider.setValue(value, displayID: display.identifier)
+    }
+    // Always update this, even without a slider. The brightness sync in
+    // AppDelegate.job() compares against it, and a stale value makes the sync
+    // push the difference to every other display.
+    display.brightnessSyncSourceValue = value
+    return true
+  }
+}

--- a/MonitorControl/Support/KeyboardShortcutsManager.swift
+++ b/MonitorControl/Support/KeyboardShortcutsManager.swift
@@ -7,6 +7,9 @@ import os.log
 class KeyboardShortcutsManager {
   private let brightnessShortcuts: [KeyboardShortcuts.Name] = [.brightnessUp, .brightnessDown, .contrastUp, .contrastDown]
   private let volumeShortcuts: [KeyboardShortcuts.Name] = [.volumeUp, .volumeDown, .mute]
+  // The preset shortcuts stay on whichever way the brightness keys are set.
+  // Most users keep the media keys, and a preset must still work for them.
+  private let presetShortcuts: [KeyboardShortcuts.Name] = BrightnessPreset.allCases.map(\.shortcutName)
 
   var initialKeyRepeat = 0.21
   var keyRepeat = 0.028
@@ -39,6 +42,13 @@ class KeyboardShortcutsManager {
     KeyboardShortcuts.onKeyDown(for: .mute) { [self] in
       self.mute()
     }
+    // A preset sets one level, so it uses no key repeat. This follows the mute
+    // shortcut, not the brightness ones.
+    for preset in BrightnessPreset.allCases {
+      KeyboardShortcuts.onKeyDown(for: preset.shortcutName) {
+        preset.apply()
+      }
+    }
     KeyboardShortcuts.onKeyUp(for: .brightnessUp) { [self] in
       self.disengage()
     }
@@ -63,7 +73,7 @@ class KeyboardShortcutsManager {
   func updateRegistrations() {
     let brightnessEnabled = [KeyboardBrightness.custom.rawValue, KeyboardBrightness.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardBrightness.rawValue))
     let volumeEnabled = [KeyboardVolume.custom.rawValue, KeyboardVolume.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue))
-    let enabledShortcuts = (brightnessEnabled ? self.brightnessShortcuts : []) + (volumeEnabled ? self.volumeShortcuts : [])
+    let enabledShortcuts = (brightnessEnabled ? self.brightnessShortcuts : []) + (volumeEnabled ? self.volumeShortcuts : []) + self.presetShortcuts
     let disabledShortcuts = (brightnessEnabled ? [] : self.brightnessShortcuts) + (volumeEnabled ? [] : self.volumeShortcuts)
 
     self.disengage()
@@ -98,6 +108,9 @@ class KeyboardShortcutsManager {
     }
     if self.volumeShortcuts.contains(shortcut) {
       return [KeyboardVolume.custom.rawValue, KeyboardVolume.both.rawValue].contains(prefs.integer(forKey: PrefKey.keyboardVolume.rawValue))
+    }
+    if self.presetShortcuts.contains(shortcut) {
+      return true
     }
     return false
   }

--- a/MonitorControl/Support/URLSchemeHandler.swift
+++ b/MonitorControl/Support/URLSchemeHandler.swift
@@ -1,0 +1,80 @@
+//  Copyright © MonitorControl. @JoniVR, @theOneyouseek, @waydabber and others
+
+import Foundation
+import os.log
+
+/// Handles the `monitorcontrol://` URL scheme.
+///
+/// The scheme lets scripts, launchers and automation apps change the
+/// brightness. It accepts these URLs:
+///
+///     monitorcontrol://brightness/set?value=10
+///     monitorcontrol://brightness/set?value=10&display=all
+///     monitorcontrol://brightness/change?delta=-10
+///     monitorcontrol://brightness/change?delta=10&display=all
+///
+/// `value` and `delta` are percentages, not fractions. Give `display=all` to
+/// change every display. Without it the app uses the display selection from
+/// the settings, the same one the brightness keys use.
+///
+/// To switch the scheme off:
+///
+///     defaults write app.monitorcontrol.MonitorControl disableExternalControl -bool true
+enum URLSchemeHandler {
+  static let scheme = "monitorcontrol"
+
+  /// Handles the URLs macOS delivered to the app.
+  static func handle(_ urls: [URL]) {
+    guard !prefs.bool(forKey: PrefKey.disableExternalControl.rawValue) else {
+      os_log("Ignoring a URL because control from other apps is off.", type: .info)
+      return
+    }
+    for url in urls where url.scheme?.lowercased() == self.scheme {
+      self.handle(url)
+    }
+  }
+
+  private static func handle(_ url: URL) {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      os_log("Ignoring a URL that cannot be read.", type: .info)
+      return
+    }
+    let group = components.host?.lowercased() ?? ""
+    let action = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/")).lowercased()
+    var query: [String: String] = [:]
+    for item in components.queryItems ?? [] {
+      query[item.name.lowercased()] = item.value
+    }
+    let allDisplays = query["display"]?.lowercased() == "all"
+
+    guard group == "brightness" else {
+      os_log("Ignoring a URL with the unknown group %{public}@.", type: .info, group)
+      return
+    }
+    switch action {
+    case "set":
+      guard let percent = self.percentage(query["value"]), percent >= 0 else {
+        os_log("Ignoring a brightness URL without a usable value.", type: .info)
+        return
+      }
+      BrightnessActions.setLevel(percent / 100, allDisplays: allDisplays, minimum: BrightnessActions.externalMinimumValue)
+    case "change":
+      guard let percent = self.percentage(query["delta"]) else {
+        os_log("Ignoring a brightness URL without a usable delta.", type: .info)
+        return
+      }
+      BrightnessActions.changeLevel(by: percent / 100, allDisplays: allDisplays, minimum: BrightnessActions.externalMinimumValue)
+    default:
+      os_log("Ignoring a brightness URL with the unknown action %{public}@.", type: .info, action)
+    }
+  }
+
+  /// Reads a percentage from a query value. Returns nil if it is missing, not a
+  /// number, or infinite.
+  private static func percentage(_ raw: String?) -> Float? {
+    guard let raw = raw, let value = Float(raw), value.isFinite else {
+      return nil
+    }
+    return value
+  }
+}

--- a/MonitorControl/UI/cs.lproj/Localizable.strings
+++ b/MonitorControl/UI/cs.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "O aplikaci";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Jas";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Ukončit";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Obnovit nastavení?";

--- a/MonitorControl/UI/de.lproj/Localizable.strings
+++ b/MonitorControl/UI/de.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Über";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Helligkeit";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Beenden";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Einstellungen zurücksetzen?";

--- a/MonitorControl/UI/en.lproj/Localizable.strings
+++ b/MonitorControl/UI/en.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "About";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Brightness";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Quit";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Reset Settings?";

--- a/MonitorControl/UI/es.lproj/Localizable.strings
+++ b/MonitorControl/UI/es.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Acerca de MonitorControl";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Brillo";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Compilación";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Cerrar";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "¿Restablecer Preferencias?";

--- a/MonitorControl/UI/fr.lproj/Localizable.strings
+++ b/MonitorControl/UI/fr.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "À Propos";
 
@@ -15,6 +18,9 @@
 
 /* Sown in menu */
 "Brightness" = "Luminosité";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Quitter";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Réinitialiser les préférences ?";

--- a/MonitorControl/UI/hi.lproj/Localizable.strings
+++ b/MonitorControl/UI/hi.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "के बारे में";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "चमक।";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "निर्माण करें";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "बाहर निकलें";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "वरीयताएँ पुनर्निर्धारित करें?";

--- a/MonitorControl/UI/hu.lproj/Localizable.strings
+++ b/MonitorControl/UI/hu.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Névjegy";
 
@@ -15,6 +18,9 @@
 
 /* Sown in menu */
 "Brightness" = "Fényerő";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Kilépés";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Alapértelmezett beállítások";

--- a/MonitorControl/UI/it.lproj/Localizable.strings
+++ b/MonitorControl/UI/it.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Informazioni";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Luminosità";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Esci";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Resetto le preferenze?";

--- a/MonitorControl/UI/ja.lproj/Localizable.strings
+++ b/MonitorControl/UI/ja.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "アプリについて";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "輝度";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "ビルド";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "終了";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "設定をリセットしますか？";

--- a/MonitorControl/UI/ko.lproj/Localizable.strings
+++ b/MonitorControl/UI/ko.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "정보";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "밝기";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "빌드";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "종료";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "설정 초기화";

--- a/MonitorControl/UI/nl.lproj/Localizable.strings
+++ b/MonitorControl/UI/nl.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Over";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Helderheid";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Afsluiten";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Reset Voorkeuren?";

--- a/MonitorControl/UI/pl.lproj/Localizable.strings
+++ b/MonitorControl/UI/pl.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "O programie";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Jasność";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Wersja";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Zamknij";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Reset ustawień?";

--- a/MonitorControl/UI/pt-BR.lproj/Localizable.strings
+++ b/MonitorControl/UI/pt-BR.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Sobre";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Brilho";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Sair";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Reiniciar Preferências?";

--- a/MonitorControl/UI/pt-PT.lproj/Localizable.strings
+++ b/MonitorControl/UI/pt-PT.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Sobre";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Brilho";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Build";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Sair";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Limpar Preferências?";

--- a/MonitorControl/UI/ru.lproj/Localizable.strings
+++ b/MonitorControl/UI/ru.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "О программе";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Яркость";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Релиз";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Выйти";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Сбросить настройки?";

--- a/MonitorControl/UI/sk.lproj/Localizable.strings
+++ b/MonitorControl/UI/sk.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "O aplikácii";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Jas";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Zostava";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Ukončiť";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Obnoviť predvoľby?";

--- a/MonitorControl/UI/tr.lproj/Localizable.strings
+++ b/MonitorControl/UI/tr.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "Hakkında";
 
@@ -15,6 +18,9 @@
 
 /* Shown in menu */
 "Brightness" = "Parlaklık";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "Sürüm";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "Çıkış";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "Ayarları Sıfırla?";

--- a/MonitorControl/UI/zh-Hans.lproj/Localizable.strings
+++ b/MonitorControl/UI/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "关于";
 
@@ -15,6 +18,9 @@
 
 /* Sown in menu */
 "Brightness" = "亮度";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "版本";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "退出";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "重置所有设置？";

--- a/MonitorControl/UI/zh-Hant-TW.lproj/Localizable.strings
+++ b/MonitorControl/UI/zh-Hant-TW.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Shown in the keyboard prefs window */
+"A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set." = "A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.";
+
 /* Shown in the main prefs window */
 "About" = "關於";
 
@@ -15,6 +18,9 @@
 
 /* Sown in menu */
 "Brightness" = "亮度";
+
+/* Shown in the keyboard prefs window */
+"Brightness presets:" = "Brightness presets:";
 
 /* Build */
 "Build" = "版號";
@@ -90,6 +96,9 @@
 
 /* Shown in menu */
 "Quit" = "離開";
+
+/* Shown in record shortcut box */
+"Record Shortcut" = "Record Shortcut";
 
 /* Shown in the alert dialog */
 "Reset Settings?" = "重置偏好設定？";

--- a/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
+++ b/MonitorControl/View Controllers/Preferences/KeyboardPrefsViewController.swift
@@ -46,6 +46,8 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
   @IBOutlet var rowUseAudioMouseText: NSGridRow!
   @IBOutlet var rowUseAudioNameText: NSGridRow!
 
+  private var presetPercentageFields: [NSTextField] = []
+
   func updateGridLayout() {
     if self.keyboardBrightness.selectedTag() == KeyboardBrightness.media.rawValue {
       self.rowKeyboardBrightnessPopUp.bottomPadding = -13
@@ -141,7 +143,127 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     self.customVolumeDown.addSubview(customVolumeDownRecorder)
     self.customMute.addSubview(customMuteRecorder)
 
+    self.addPresetRows()
     self.populateSettings()
+  }
+
+  /// Builds the brightness preset rows and adds them to the grid.
+  ///
+  /// This is written in code on purpose. Every label placed in the storyboard
+  /// needs an entry in 19 Main.strings files, keyed by object identifier. Built
+  /// here, the new text lives in Localizable.strings only.
+  private func addPresetRows() {
+    guard let grid = self.rowCustomBrightnessShortcuts?.gridView else {
+      return
+    }
+
+    let separator = NSBox()
+    separator.boxType = .separator
+    let separatorRow = grid.addRow(with: [separator])
+    separatorRow.mergeCells(in: NSRange(location: 0, length: grid.numberOfColumns))
+    separatorRow.topPadding = 10
+    separatorRow.bottomPadding = 10
+
+    for preset in BrightnessPreset.allCases {
+      let formatter = NumberFormatter()
+      formatter.allowsFloats = false
+      formatter.minimum = 0
+      formatter.maximum = 100
+
+      let percentage = NSTextField()
+      percentage.formatter = formatter
+      percentage.alignment = .right
+      percentage.tag = preset.rawValue
+      percentage.target = self
+      percentage.action = #selector(self.presetPercentageChanged(_:))
+      // The action alone fires only on Return. Without the delegate a level
+      // typed and left uncommitted would never reach the settings.
+      percentage.delegate = self
+      percentage.translatesAutoresizingMaskIntoConstraints = false
+      percentage.widthAnchor.constraint(equalToConstant: 48).isActive = true
+      self.presetPercentageFields.append(percentage)
+
+      let recorder = KeyboardShortcuts.RecorderCocoa(for: preset.shortcutName)
+      recorder.placeholderString = NSLocalizedString("Record Shortcut", comment: "Shown in record shortcut box")
+      recorder.translatesAutoresizingMaskIntoConstraints = false
+      recorder.widthAnchor.constraint(equalToConstant: 170).isActive = true
+
+      let controls = NSStackView(views: [percentage, NSTextField(labelWithString: "%"), recorder])
+      controls.orientation = .horizontal
+      controls.spacing = 6
+
+      // Every row is built the same way, and only the first one carries the
+      // caption. Giving the other rows a shared empty placeholder instead left
+      // their controls unable to take a click.
+      let isFirst = preset == BrightnessPreset.allCases.first
+      let caption = NSTextField(labelWithString: isFirst ? NSLocalizedString("Brightness presets:", comment: "Shown in the keyboard prefs window") : "")
+      caption.alignment = .right
+
+      let row = grid.addRow(with: self.gridCells(in: grid, leading: caption, trailing: controls))
+      row.cell(at: 0).xPlacement = .trailing
+    }
+
+    let hint = NSTextField(wrappingLabelWithString: NSLocalizedString("A preset sets every display to a fixed brightness. Presets work whichever way the brightness keys above are set.", comment: "Shown in the keyboard prefs window"))
+    hint.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+    hint.textColor = .secondaryLabelColor
+    grid.addRow(with: self.gridCells(in: grid, leading: nil, trailing: hint))
+  }
+
+  /// Returns one view per grid column, with the labels on the left and the
+  /// controls in the last column, the way the rows above are arranged.
+  private func gridCells(in grid: NSGridView, leading: NSView?, trailing: NSView?) -> [NSView] {
+    var cells: [NSView] = (0 ..< max(1, grid.numberOfColumns)).map { _ in NSGridCell.emptyContentView }
+    if let leading = leading {
+      cells[0] = leading
+    }
+    if let trailing = trailing {
+      cells[cells.count - 1] = trailing
+    }
+    return cells
+  }
+
+  @objc func presetPercentageChanged(_ sender: NSTextField) {
+    self.storePresetPercentage(from: sender)
+    self.presetOf(sender).map { sender.integerValue = $0.percentage }
+  }
+
+  /// Returns the preset a percentage box belongs to.
+  ///
+  /// The box has to be one of ours. Other text fields in this tab carry tag 0,
+  /// which would otherwise look like the first preset.
+  private func presetOf(_ field: NSTextField) -> BrightnessPreset? {
+    guard self.presetPercentageFields.contains(where: { $0 === field }) else {
+      return nil
+    }
+    return BrightnessPreset(rawValue: field.tag)
+  }
+
+  private func storePresetPercentage(from field: NSTextField) {
+    guard let preset = self.presetOf(field), !field.stringValue.isEmpty else {
+      return
+    }
+    preset.percentage = field.integerValue
+  }
+}
+
+extension KeyboardPrefsViewController: NSTextFieldDelegate {
+  /// Saves the level while it is typed, so a preset works even when the box
+  /// was never committed with Return.
+  func controlTextDidChange(_ notification: Notification) {
+    guard let field = notification.object as? NSTextField else {
+      return
+    }
+    self.storePresetPercentage(from: field)
+  }
+
+  /// Puts the stored level back in the box, which also shows the user the
+  /// clamped value after an entry outside 0 to 100.
+  func controlTextDidEndEditing(_ notification: Notification) {
+    guard let field = notification.object as? NSTextField, let preset = self.presetOf(field) else {
+      return
+    }
+    self.storePresetPercentage(from: field)
+    field.integerValue = preset.percentage
   }
 
   func populateSettings() {
@@ -153,6 +275,11 @@ class KeyboardPrefsViewController: NSViewController, SettingsPane {
     self.useFineScale.state = prefs.bool(forKey: PrefKey.useFineScaleBrightness.rawValue) ? .on : .off
     self.useFineScaleVolume.state = prefs.bool(forKey: PrefKey.useFineScaleVolume.rawValue) ? .on : .off
     self.separateCombinedScale.state = prefs.bool(forKey: PrefKey.separateCombinedScale.rawValue) ? .on : .off
+    for field in self.presetPercentageFields {
+      if let preset = BrightnessPreset(rawValue: field.tag) {
+        field.integerValue = preset.percentage
+      }
+    }
     self.updateGridLayout()
   }
 


### PR DESCRIPTION
## What this adds

Two related things, in three commits that can be taken separately:

1. **Four brightness presets.** Each has a percentage you set and a shortcut
   you record. A preset sets every display to that level.
2. **A `monitorcontrol://` URL scheme**, so a script or a launcher can do the
   same thing.

```
monitorcontrol://brightness/set?value=10&display=all
monitorcontrol://brightness/change?delta=-10
```

Both go through one small shared file, `BrightnessActions.swift`, so the two
entry points cannot drift apart.

## Why

The most common request I could find in this repo is a key that dims every
screen when you leave the desk, and a key that puts them back: #1851, #1674,
#727, #795, #1224. Related asks for outside control: #682, #1515, #1620, #1858.

I understand the answer has been that MonitorControl stays simple, and that
BetterDisplay covers this. I still think this specific shape is small enough to
fit: it adds no new window, no new tab, and nothing changes for a user who
never records a preset shortcut.

**Please close this if you disagree.** I will keep using my fork and I will not
argue the point.

## Design notes

- `Display.setBrightness` already existed and already picks DDC, the Apple
  protocol, gamma, or the shade layer. Nothing in that path is touched.
- The new action repeats the three side effects of `stepBrightness`: the OSD,
  the menu slider, and `brightnessSyncSourceValue`. The last one matters,
  because `AppDelegate.job()` compares against it and a stale value makes the
  sync push the difference to every other display.
- A relative URL change does its arithmetic per display inside the app. A
  caller therefore never has to read the brightness first. Many monitors accept
  writes but return noise on reads.
- Presets stay active whichever way the brightness keys are set. Most users
  keep the media keys, and a preset must still work for them.
- The settings rows are built in code, not in the storyboard, to keep the new
  text in `Localizable.strings` only instead of 19 `Main.strings` files.
- Any app can open a URL, so `disableExternalControl` switches the scheme off
  and a 1% floor stops a URL from making a screen fully black.
- No change to the deployment target. App Intents would have needed macOS 13.

## Testing

Built and run on macOS 26.5.2, Apple silicon, with 4 external displays
(3x LG UltraFine, 1x N27p) in clamshell mode. Two of those monitors accept DDC
writes but return noise on reads, which made them a useful test.

Checked: absolute set, relative change, all four displays reaching the target,
the OSD, the menu sliders, the brightness sync not fighting the change, the 1%
floor, the off switch, and malformed URLs (`value=abc`, `value=999`, unknown
action) being ignored without a crash.

The diff carries no SwiftFormat churn and no `CFBundleVersion` bumps.

## Disclosure

This was written with AI assistance (Claude). You said on 2026-05-09 that you
do not review AI generated PRs, and asked to be told. So: this is one. I am not
asking you to make an exception. If the `AI contribution / fork recommendation`
label is the right home for it, that is completely fine, and the fork is at
https://github.com/Erik5000/MonitorControl for anyone who wants the feature.

Every line was read, built, and tested on real hardware before opening this.
